### PR TITLE
Add ability to skip slugs from config file

### DIFF
--- a/packages/algolia-fragmenter/lib/transformer.js
+++ b/packages/algolia-fragmenter/lib/transformer.js
@@ -75,7 +75,7 @@ module.exports._testReduceFragmentsUnderHeadings = reduceFragmentsUnderHeadings;
  *
  *  @param {Array} posts
  */
-module.exports.transformToAlgoliaObject = (posts) => {
+module.exports.transformToAlgoliaObject = (posts, ignoreSlugs) => {
     const algoliaObjects = [];
 
     posts.map((post) => {
@@ -90,6 +90,14 @@ module.exports.transformToAlgoliaObject = (posts) => {
             tags: [],
             authors: []
         };
+
+        // If we have an array of slugs to ignore, and the current
+        // post slug is in that list, skip this loop iteration
+        if (ignoreSlugs) {
+            if (ignoreSlugs.includes(post.slug)) {
+                return false;
+            }
+        }
 
         post.tags.forEach((tag) => {
             algoliaPost.tags.push({name: tag.name, slug: tag.slug});

--- a/packages/algolia/README.md
+++ b/packages/algolia/README.md
@@ -40,6 +40,8 @@ yarn algolia index <pathToConfig> -s post-slug-to-exclude,and-another-post-slug-
 
 - `-V, --verbose`, switches on verbose mode, but there's not much too see here (yet)
 
+- `-sjs --skipjsonslugs`, uses a list of slugs in `config.json` to skip before they're uploaded. This method will request all data from Ghost and skip at the point it would normally upload to Algolia. If you're getting `414 Request-URI Too Large` errors using `-s`, this is the method to use.
+
 ## Develop
 
 This is a mono repository, managed with [lerna](https://lernajs.io/).

--- a/packages/algolia/bin/cli.js
+++ b/packages/algolia/bin/cli.js
@@ -23,6 +23,10 @@ prettyCLI.command({
             defaultValue: [],
             desc: 'Comma separated list of post slugs to exclude from indexing'
         });
+        sywac.array('-sjs --skipjsonslugs', {
+            defaultValue: false,
+            desc: 'Exclude post slugs from config JSON file'
+        });
     },
     run: async (argv) => {
         const mainTimer = Date.now();
@@ -75,7 +79,13 @@ prettyCLI.command({
 
             ui.log.info('Transforming and fragmenting posts...');
 
-            context.posts = transforms.transformToAlgoliaObject(context.posts);
+            if (argv.skipjsonslugs) {
+                const ignoreSlugsCount = context.ignore_slugs.length;
+
+                ui.log.info(`Skipping the ${ignoreSlugsCount} slugs in ${argv.pathToConfig}`);
+            }
+
+            context.posts = transforms.transformToAlgoliaObject(context.posts, context.ignore_slugs);
 
             context.fragments = context.posts.reduce(transforms.fragmentTransformer, []);
 

--- a/packages/algolia/example.config.json
+++ b/packages/algolia/example.config.json
@@ -3,6 +3,9 @@
     "apiKey": "",
     "apiUrl": ""
   },
+  "ignore_slugs": [
+    "the-slug-of-a-post-with-a-huge-amount-of-content-that-will-cause-errors"
+  ],
   "algolia": {
     "index": "",
     "apiKey": "",
@@ -24,7 +27,9 @@
         "authors.name",
         "authors"
       ],
-      "attributesForFaceting": ["filterOnly(slug)"]
+      "attributesForFaceting": [
+        "filterOnly(slug)"
+      ]
     }
   }
 }


### PR DESCRIPTION
Adds the `-sjs --skipjsonslugs` flag, which uses a list of slugs in `config.json` to skip before they're uploaded.

This method is useful if you have a very large list of slugs to skip and are getting getting `414 Request-URI Too Large` errors when  using `-s`.