### PR TITLE
Removed unused indexer error dependency

### DIFF
--- a/packages/algolia-indexer/package.json
+++ b/packages/algolia-indexer/package.json
@@ -24,7 +24,6 @@
     "sinon": "17.0.1"
   },
   "dependencies": {
-    "@tryghost/errors": "1.2.27",
     "algoliasearch": "4.20.0"
   }
 }


### PR DESCRIPTION
## Summary

- Remove the unused `@tryghost/errors` declaration from `@tryghost/algolia-indexer`.
- Keep the CLI workspace declaration because `packages/algolia/lib/utils.js` imports it directly.
- Leave `yarn.lock` unchanged because the same exact package resolution remains required by the CLI.

## Knip evidence

- Ran `npx --yes knip --dependencies` from the monorepo root.
- Confirmed the indexer has no source, test, script, dynamic-load, peer, optional, bundled, workflow, or documentation reference to `@tryghost/errors`.
- Re-ran Knip after removal; the indexer finding is gone.
- Retained the reported Netlify workspace dependencies because the function entry points import them directly; Knip misses those nonstandard package entries.
- Retained the reported `lerna` and `algolia` binaries because they belong to the maintainer release script and package-owned CLI respectively.

## Verification

- Node 18.20.8 / Yarn 1.22.22 frozen install
- `yarn test`
- `yarn lint`
- `npm pack --dry-run` for `@tryghost/algolia-indexer`
- `git diff --check`

No package-manager migration, CI gate, Renovate, lint configuration, documentation rewrite, source change, or unrelated dependency update is included.