### PR TITLE
Added Ghost 6 pagination support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@ This repository contains the Ghost-to-Algolia CLI, Netlify Functions, and their 
 ## Revival and Ghost 6 compatibility
 
 - Maintenance is resuming because these tools are still in active use.
-- The current CLI relies on the removed Ghost 6 `limit=all` behavior and can fetch only the first 100 posts. Treat [#163](https://github.com/TryGhost/algolia/issues/163) as the compatibility source of truth and keep the limitation visible until pagination is implemented and tested.
+- The CLI uses the Ghost 6 Content API. Without `--limit`, it requests 100 posts per page, follows `meta.pagination.next`, and waits 100ms between pages until `next` is `null`.
+- `--limit` accepts only integers from 1 to 100 and makes one request. `--page` requires `--limit`; together they select one page rather than enabling automatic pagination.
 - Preserve the existing Ghost Content API, Algolia record, CLI, and webhook contracts unless the task explicitly changes them.
 
 ## Verification

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 JavaScript tools for turning Ghost posts into records and keeping an Algolia search index up to date.
 
 > [!IMPORTANT]
-> Maintenance of this repository is resuming. Ghost 6 removed support for `limit=all`, so the current CLI releases index only the first 100 posts from a Ghost 6 site. Follow [#163](https://github.com/TryGhost/algolia/issues/163) for the compatibility work; Ghost 6 compatibility is not yet complete.
+> Maintenance of this repository has resumed. The CLI supports Ghost 6 by requesting up to 100 posts at a time and following Ghost's pagination metadata until every post has been fetched.
 
 ## Tools
 

--- a/packages/algolia/README.md
+++ b/packages/algolia/README.md
@@ -2,8 +2,7 @@
 
 `@tryghost/algolia` is a CLI for initially indexing the full published content of a Ghost site in Algolia.
 
-> [!WARNING]
-> Ghost 6 removed support for `limit=all`, so the current CLI releases index only the first 100 posts from a Ghost 6 site. Follow [#163](https://github.com/TryGhost/algolia/issues/163) for the compatibility work.
+The CLI uses the Ghost 6 Content API. By default, it requests the [maximum 100 posts](https://docs.ghost.org/content-api/parameters#limit) at a time, follows Ghost's [`meta.pagination.next`](https://docs.ghost.org/content-api/pagination) value, and pauses briefly between pages until the full site has been fetched.
 
 ## Install
 
@@ -43,8 +42,8 @@ node bin/cli.js index config.json [options]
 - `pathToConfig` is the path, relative to the current directory, to the JSON configuration file.
 - `-s, --skip` excludes a comma-separated list of post slugs from the index.
 - `-V, --verbose` enables verbose output.
-- `-l, --limit` limits the number of posts requested.
-- `-p, --page` selects a page and is intended for use with `--limit`.
+- `-l, --limit` makes a single request for 1 to 100 posts instead of fetching every page.
+- `-p, --page` selects the page for that single request and requires `--limit`.
 - `-sjs, --skipjsonslugs` currently controls only a log message about `ignore_slugs`; it does not control exclusion. Configured `ignore_slugs` are always excluded after posts are fetched.
 
 ### Large fragments

--- a/packages/algolia/bin/cli.js
+++ b/packages/algolia/bin/cli.js
@@ -3,6 +3,7 @@ const prettyCLI = require('@tryghost/pretty-cli');
 const ui = require('@tryghost/pretty-cli').ui;
 const fs = require('fs-extra');
 const utils = require('../lib/utils');
+const {fetchPosts} = require('../lib/fetch-posts');
 const GhostContentAPI = require('@tryghost/content-api');
 const transforms = require('@tryghost/algolia-fragmenter');
 const IndexFactory = require('@tryghost/algolia-indexer');
@@ -24,14 +25,27 @@ prettyCLI.command({
             desc: 'Comma separated list of post slugs to exclude from indexing'
         });
         sywac.number('-l --limit', {
-            desc: 'Amount of posts we want to fetch from Ghost'
+            desc: 'Fetch one page containing 1 to 100 posts'
         });
         sywac.number('-p --page', {
-            desc: 'Use page to navigate through posts when setting a limit'
+            desc: 'Select a page; requires --limit'
         });
         sywac.array('-sjs --skipjsonslugs', {
             defaultValue: false,
             desc: 'Exclude post slugs from config JSON file'
+        });
+        sywac.check((argv, context) => {
+            if (argv.limit !== undefined && (!Number.isInteger(argv.limit) || argv.limit < 1 || argv.limit > 100)) {
+                context.cliMessage('--limit must be an integer from 1 to 100.');
+            }
+
+            if (argv.page !== undefined && argv.limit === undefined) {
+                context.cliMessage('--page requires --limit.');
+            }
+
+            if (argv.page !== undefined && (!Number.isInteger(argv.page) || argv.page < 1)) {
+                context.cliMessage('--page must be a positive integer.');
+            }
         });
     },
     run: async (argv) => {
@@ -56,31 +70,31 @@ prettyCLI.command({
         // 2. Fetch all posts from the Ghost instance
         try {
             const timer = Date.now();
-            const params = {limit: 'all', include: 'tags,authors'};
+            const fetchOptions = {};
             const ghost = new GhostContentAPI({
                 url: context.ghost.apiUrl,
                 key: context.ghost.apiKey,
-                version: 'canary'
+                version: 'v6.0'
             });
 
             if (argv.skip && argv.skip.length > 0) {
                 const filterSlugs = argv.skip.join(',');
 
-                params.filter = `slug:-[${filterSlugs}]`;
+                fetchOptions.filter = `slug:-[${filterSlugs}]`;
             }
 
-            if (argv.limit) {
-                params.limit = argv.limit;
+            if (argv.limit !== undefined) {
+                fetchOptions.limit = argv.limit;
             }
 
-            ui.log.info(`Fetching ${params.limit} posts from Ghost...`);
+            ui.log.info(`Fetching ${argv.limit === undefined ? 'all' : argv.limit} posts from Ghost...`);
 
-            if (argv.page) {
+            if (argv.page !== undefined) {
                 ui.log.info(`...from page #${argv.page}.`);
-                params.page = argv.page;
+                fetchOptions.page = argv.page;
             }
 
-            context.posts = await ghost.posts.browse(params);
+            context.posts = await fetchPosts(ghost.posts.browse.bind(ghost.posts), fetchOptions);
 
             ui.log.info(`Done fetching posts in ${Date.now() - timer}ms.`);
         } catch (error) {

--- a/packages/algolia/lib/fetch-posts.js
+++ b/packages/algolia/lib/fetch-posts.js
@@ -1,0 +1,73 @@
+const DEFAULT_PAGE_SIZE = 100;
+const PAGE_DELAY_MS = 100;
+
+const waitBetweenPages = () => {
+    return new Promise((resolve) => {
+        setTimeout(resolve, PAGE_DELAY_MS);
+    });
+};
+
+const getNextPage = (posts) => {
+    if (!posts.meta || !posts.meta.pagination || typeof posts.meta.pagination !== 'object') {
+        throw TypeError('Ghost returned posts without pagination metadata.');
+    }
+
+    const nextPage = posts.meta.pagination.next;
+
+    if (nextPage !== null && (!Number.isInteger(nextPage) || nextPage < 1)) {
+        throw TypeError('Ghost returned an invalid next page.');
+    }
+
+    return nextPage;
+};
+
+const validatePosts = (posts) => {
+    if (!Array.isArray(posts)) {
+        throw TypeError('Ghost returned posts in an invalid format.');
+    }
+};
+
+module.exports.fetchPosts = async (browsePosts, options = {}) => {
+    const hasExplicitLimit = options.limit !== undefined;
+    const params = {include: 'tags,authors'};
+
+    if (hasExplicitLimit) {
+        params.limit = options.limit;
+        if (options.page !== undefined) {
+            params.page = options.page;
+        }
+    } else {
+        params.limit = DEFAULT_PAGE_SIZE;
+        params.page = 1;
+    }
+
+    if (options.filter !== undefined) {
+        params.filter = options.filter;
+    }
+
+    const firstPage = await browsePosts(params);
+    validatePosts(firstPage);
+    const posts = [...firstPage];
+
+    if (hasExplicitLimit) {
+        return posts;
+    }
+
+    let nextPage = getNextPage(firstPage);
+    const fetchedPages = new Set([1]);
+
+    while (nextPage !== null) {
+        if (fetchedPages.has(nextPage)) {
+            throw TypeError('Ghost returned a repeated next page.');
+        }
+
+        fetchedPages.add(nextPage);
+        await waitBetweenPages();
+        const page = await browsePosts({...params, page: nextPage});
+        validatePosts(page);
+        posts.push(...page);
+        nextPage = getNextPage(page);
+    }
+
+    return posts;
+};

--- a/packages/algolia/package.json
+++ b/packages/algolia/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@tryghost/algolia-fragmenter": "^0.2.7",
     "@tryghost/algolia-indexer": "^0.3.1",
-    "@tryghost/content-api": "1.11.20",
+    "@tryghost/content-api": "1.12.10",
     "@tryghost/errors": "1.2.27",
     "@tryghost/pretty-cli": "1.2.39",
     "fs-extra": "11.1.1"

--- a/packages/algolia/test/cli.test.js
+++ b/packages/algolia/test/cli.test.js
@@ -1,0 +1,101 @@
+require('./utils');
+
+const path = require('path');
+const {spawnSync} = require('child_process');
+
+const CLI_PATH = path.join(__dirname, '..', 'bin', 'cli.js');
+const MISSING_CONFIG_PATH = path.join(__dirname, 'missing-config.json');
+const CONFIG_PATH = path.join(__dirname, 'fixtures', 'cli-config.json');
+const MOCK_DEPENDENCIES_PATH = path.join(__dirname, 'fixtures', 'mock-cli-dependencies.js');
+const INVALID_LIMITS = ['not-a-number', '0', '-1', '1.5', '101'];
+const INVALID_PAGES = ['not-a-number', '0', '-1', '1.5'];
+
+const runCli = (args, options = {}) => {
+    const env = {...process.env};
+
+    if (options.mockDependencies) {
+        env.NODE_OPTIONS = [env.NODE_OPTIONS, `--require=${MOCK_DEPENDENCIES_PATH}`].filter(Boolean).join(' ');
+    }
+
+    return spawnSync(process.execPath, [CLI_PATH, ...args], {
+        encoding: 'utf8',
+        env
+    });
+};
+
+const getOutput = (result) => {
+    return `${result.stdout}${result.stderr}`;
+};
+
+const getLoggedValues = (output, marker) => {
+    return output
+        .split('\n')
+        .filter(line => line.startsWith(`${marker} `))
+        .map(line => JSON.parse(line.slice(marker.length + 1)));
+};
+
+describe('algolia CLI', function () {
+    it('rejects page without limit before loading config', function () {
+        const result = runCli(['index', MISSING_CONFIG_PATH, '--page', '2']);
+        const output = getOutput(result);
+
+        result.status.should.not.eql(0);
+        output.should.match(/--page requires --limit/);
+        output.should.not.match(/--page must be a positive integer/);
+        output.should.not.match(/Failed loading JSON config file/);
+    });
+
+    for (const limit of INVALID_LIMITS) {
+        it(`rejects limit ${limit} before loading config`, function () {
+            const result = runCli(['index', MISSING_CONFIG_PATH, '--limit', limit]);
+            const output = getOutput(result);
+
+            result.status.should.not.eql(0);
+            output.should.match(/--limit must be an integer from 1 to 100/);
+            output.should.not.match(/Failed loading JSON config file/);
+        });
+    }
+
+    for (const page of INVALID_PAGES) {
+        it(`rejects page ${page} before loading config`, function () {
+            const result = runCli(['index', MISSING_CONFIG_PATH, '--limit', '100', '--page', page]);
+            const output = getOutput(result);
+
+            result.status.should.not.eql(0);
+            output.should.match(/--page must be a positive integer/);
+            output.should.not.match(/Failed loading JSON config file/);
+            output.should.not.match(/GHOST_CLIENT|GHOST_BROWSE/);
+        });
+    }
+
+    it('indexes every Ghost page through a Ghost 6 client', function () {
+        const result = runCli(['index', CONFIG_PATH], {mockDependencies: true});
+        const output = getOutput(result);
+
+        result.status.should.eql(0);
+        getLoggedValues(output, 'GHOST_CLIENT').should.eql([{
+            url: 'https://example.test',
+            key: 'test-content-api-key',
+            version: 'v6.0'
+        }]);
+        getLoggedValues(output, 'GHOST_BROWSE').should.eql([
+            {limit: 100, page: 1, include: 'tags,authors'},
+            {limit: 100, page: 2, include: 'tags,authors'}
+        ]);
+        output.should.match(/2 Fragments successfully saved/);
+    });
+
+    it('accepts the inclusive limit bounds in one-page mode', function () {
+        const firstPost = runCli(['index', CONFIG_PATH, '--limit', '1'], {mockDependencies: true});
+        const requestedPage = runCli(['index', CONFIG_PATH, '--limit', '100', '--page', '3'], {mockDependencies: true});
+
+        firstPost.status.should.eql(0);
+        getLoggedValues(getOutput(firstPost), 'GHOST_BROWSE').should.eql([
+            {limit: 1, include: 'tags,authors'}
+        ]);
+        requestedPage.status.should.eql(0);
+        getLoggedValues(getOutput(requestedPage), 'GHOST_BROWSE').should.eql([
+            {limit: 100, page: 3, include: 'tags,authors'}
+        ]);
+    });
+});

--- a/packages/algolia/test/fetch-posts.test.js
+++ b/packages/algolia/test/fetch-posts.test.js
@@ -1,0 +1,226 @@
+require('./utils');
+
+const assert = require('assert/strict');
+const {fetchPosts} = require('../lib/fetch-posts');
+
+describe('fetchPosts', function () {
+    it('fetches the first page with Ghost 6 pagination defaults', async function () {
+        const posts = [{id: 'first-post'}];
+        posts.meta = {pagination: {next: null}};
+        const browsePosts = sinon.stub().resolves(posts);
+
+        const result = await fetchPosts(browsePosts);
+
+        result.should.eql([{id: 'first-post'}]);
+        browsePosts.calledOnceWithExactly({
+            limit: 100,
+            page: 1,
+            include: 'tags,authors'
+        }).should.be.true();
+    });
+
+    it('follows Ghost pagination after waiting between pages', async function () {
+        const firstPage = [{id: 'first-post'}];
+        firstPage.meta = {pagination: {next: 3}};
+        const secondPage = [{id: 'second-post'}];
+        secondPage.meta = {pagination: {next: null}};
+        const browsePosts = sinon.stub();
+        browsePosts.onFirstCall().resolves(firstPage);
+        browsePosts.onSecondCall().resolves(secondPage);
+        const clock = sinon.useFakeTimers();
+
+        try {
+            const resultPromise = fetchPosts(browsePosts, {filter: 'slug:-[skip-me]'});
+            await clock.tickAsync(99);
+            browsePosts.calledOnce.should.be.true();
+
+            await clock.tickAsync(1);
+            const result = await resultPromise;
+
+            result.should.eql([{id: 'first-post'}, {id: 'second-post'}]);
+            browsePosts.firstCall.calledWithExactly({
+                limit: 100,
+                page: 1,
+                include: 'tags,authors',
+                filter: 'slug:-[skip-me]'
+            }).should.be.true();
+            browsePosts.secondCall.calledWithExactly({
+                limit: 100,
+                page: 3,
+                include: 'tags,authors',
+                filter: 'slug:-[skip-me]'
+            }).should.be.true();
+        } finally {
+            clock.restore();
+        }
+    });
+
+    it('fetches only the requested limit when a limit is explicit', async function () {
+        const browsePosts = sinon.stub().resolves([{id: 'limited-post'}]);
+
+        const result = await fetchPosts(browsePosts, {limit: 20});
+
+        result.should.eql([{id: 'limited-post'}]);
+        browsePosts.calledOnceWithExactly({
+            limit: 20,
+            include: 'tags,authors'
+        }).should.be.true();
+    });
+
+    it('fetches only the requested page when limit and page are explicit', async function () {
+        const requestedPage = [{id: 'requested-post'}];
+        requestedPage.meta = {pagination: {next: 4}};
+        const browsePosts = sinon.stub().resolves(requestedPage);
+
+        const result = await fetchPosts(browsePosts, {limit: 10, page: 3});
+
+        result.should.eql([{id: 'requested-post'}]);
+        browsePosts.calledOnceWithExactly({
+            limit: 10,
+            page: 3,
+            include: 'tags,authors'
+        }).should.be.true();
+    });
+
+    it('rejects a non-array response in automatic pagination mode', async function () {
+        const browsePosts = sinon.stub().resolves({meta: {pagination: {next: null}}});
+
+        await assert.rejects(
+            fetchPosts(browsePosts),
+            {
+                name: 'TypeError',
+                message: 'Ghost returned posts in an invalid format.'
+            }
+        );
+    });
+
+    it('rejects missing pagination metadata in automatic mode', async function () {
+        const browsePosts = sinon.stub().resolves([{id: 'post-without-meta'}]);
+
+        await assert.rejects(
+            fetchPosts(browsePosts),
+            {
+                name: 'TypeError',
+                message: 'Ghost returned posts without pagination metadata.'
+            }
+        );
+    });
+
+    it('rejects a non-array response from a later page', async function () {
+        const firstPage = [{id: 'first-post'}];
+        firstPage.meta = {pagination: {next: 2}};
+        const browsePosts = sinon.stub();
+        browsePosts.onFirstCall().resolves(firstPage);
+        browsePosts.onSecondCall().resolves({meta: {pagination: {next: null}}});
+        const clock = sinon.useFakeTimers();
+
+        try {
+            const resultPromise = fetchPosts(browsePosts);
+            const rejection = assert.rejects(
+                resultPromise,
+                {
+                    name: 'TypeError',
+                    message: 'Ghost returned posts in an invalid format.'
+                }
+            );
+
+            await clock.tickAsync(100);
+            await rejection;
+        } finally {
+            clock.restore();
+        }
+    });
+
+    it('rejects missing pagination metadata from a later page', async function () {
+        const firstPage = [{id: 'first-post'}];
+        firstPage.meta = {pagination: {next: 2}};
+        const browsePosts = sinon.stub();
+        browsePosts.onFirstCall().resolves(firstPage);
+        browsePosts.onSecondCall().resolves([{id: 'post-without-meta'}]);
+        const clock = sinon.useFakeTimers();
+
+        try {
+            const resultPromise = fetchPosts(browsePosts);
+            const rejection = assert.rejects(
+                resultPromise,
+                {
+                    name: 'TypeError',
+                    message: 'Ghost returned posts without pagination metadata.'
+                }
+            );
+
+            await clock.tickAsync(100);
+            await rejection;
+        } finally {
+            clock.restore();
+        }
+    });
+
+    it('rejects an invalid next page value', async function () {
+        for (const nextPage of [undefined, 0, -1, 1.5, '2']) {
+            const posts = [{id: 'first-post'}];
+            posts.meta = {pagination: {next: nextPage}};
+            const browsePosts = sinon.stub().resolves(posts);
+
+            await assert.rejects(
+                fetchPosts(browsePosts),
+                {
+                    name: 'TypeError',
+                    message: 'Ghost returned an invalid next page.'
+                }
+            );
+        }
+    });
+
+    it('rejects a repeated next page', async function () {
+        const firstPage = [{id: 'first-post'}];
+        firstPage.meta = {pagination: {next: 2}};
+        const repeatedPage = [{id: 'repeated-post'}];
+        repeatedPage.meta = {pagination: {next: 2}};
+        const finalPage = [{id: 'final-post'}];
+        finalPage.meta = {pagination: {next: null}};
+        const browsePosts = sinon.stub();
+        browsePosts.onFirstCall().resolves(firstPage);
+        browsePosts.onSecondCall().resolves(repeatedPage);
+        browsePosts.onThirdCall().resolves(finalPage);
+        const clock = sinon.useFakeTimers();
+
+        try {
+            const resultPromise = fetchPosts(browsePosts);
+            const rejection = assert.rejects(
+                resultPromise,
+                {
+                    name: 'TypeError',
+                    message: 'Ghost returned a repeated next page.'
+                }
+            );
+
+            await clock.tickAsync(200);
+            await rejection;
+        } finally {
+            clock.restore();
+        }
+    });
+
+    it('rejects pagination back to the initial page', async function () {
+        const posts = [{id: 'first-post'}];
+        posts.meta = {pagination: {next: 1}};
+        const browsePosts = sinon.stub().resolves(posts);
+
+        await assert.rejects(
+            fetchPosts(browsePosts),
+            {
+                name: 'TypeError',
+                message: 'Ghost returned a repeated next page.'
+            }
+        );
+        browsePosts.calledOnce.should.be.true();
+    });
+
+    it('propagates Ghost request errors unchanged', async function () {
+        const ghostError = Error('Ghost request failed');
+        const browsePosts = sinon.stub().rejects(ghostError);
+
+        await assert.rejects(fetchPosts(browsePosts), error => error === ghostError);
+    });
+});

--- a/packages/algolia/test/fixtures/cli-config.json
+++ b/packages/algolia/test/fixtures/cli-config.json
@@ -1,0 +1,12 @@
+{
+  "ghost": {
+    "apiKey": "test-content-api-key",
+    "apiUrl": "https://example.test"
+  },
+  "ignore_slugs": [],
+  "algolia": {
+    "index": "test-index",
+    "apiKey": "test-algolia-key",
+    "appId": "test-app"
+  }
+}

--- a/packages/algolia/test/fixtures/mock-cli-dependencies.js
+++ b/packages/algolia/test/fixtures/mock-cli-dependencies.js
@@ -1,0 +1,48 @@
+const Module = require('module');
+
+const originalLoad = Module._load;
+let browseCount = 0;
+
+class GhostContentAPI {
+    constructor(options) {
+        process.stdout.write(`GHOST_CLIENT ${JSON.stringify(options)}\n`);
+
+        this.posts = {
+            browse: async (params) => {
+                browseCount += 1;
+                process.stdout.write(`GHOST_BROWSE ${JSON.stringify(params)}\n`);
+
+                const posts = [{id: `post-${browseCount}`}];
+                posts.meta = {pagination: {next: browseCount === 1 ? 2 : null}};
+                return posts;
+            }
+        };
+    }
+}
+
+const transforms = {
+    transformToAlgoliaObject: posts => posts,
+    fragmentTransformer: (fragments, post) => fragments.concat(post)
+};
+
+class IndexFactory {
+    async setSettingsForIndex() {}
+
+    async save() {}
+}
+
+Module._load = function (request) {
+    if (request === '@tryghost/content-api') {
+        return GhostContentAPI;
+    }
+
+    if (request === '@tryghost/algolia-fragmenter') {
+        return transforms;
+    }
+
+    if (request === '@tryghost/algolia-indexer') {
+        return IndexFactory;
+    }
+
+    return originalLoad.apply(this, arguments);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2660,12 +2660,12 @@
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
   integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
 
-"@tryghost/content-api@1.11.20":
-  version "1.11.20"
-  resolved "https://registry.yarnpkg.com/@tryghost/content-api/-/content-api-1.11.20.tgz#5b3ccb432e9e2f74a2bd6726aa8af8d1de2d3fbf"
-  integrity sha512-VlCfHP4IMHjTx2iIP+xXT7lUmZalC8StSTchgrfQtIIOkbtd5lNnklqnfUuo2teI8Fag28/KwrLXRVg1g/wO+A==
+"@tryghost/content-api@1.12.10":
+  version "1.12.10"
+  resolved "https://registry.yarnpkg.com/@tryghost/content-api/-/content-api-1.12.10.tgz#f331a81c01452a5680d5c0cfda8f87714c3c7290"
+  integrity sha512-lESZtuKKiEUsagsfUb/oxjasLKjh3gHCmUgyfdvwgcoO58GGb8UFOakZuB0ih0dpIS1IQ+hDS2KJujdgFetPog==
   dependencies:
-    axios "^1.0.0"
+    axios "1.18.1"
 
 "@tryghost/errors@1.2.27":
   version "1.2.27"
@@ -3602,7 +3602,17 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
   integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
 
-axios@^1.0.0, axios@^1.1.3:
+axios@1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.18.1.tgz#d63f9863bcd8938815c86f9e2abd380189d96dfe"
+  integrity sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==
+  dependencies:
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
+
+axios@^1.1.3:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
   integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
@@ -4013,6 +4023,14 @@ cachedir@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.4.0.tgz#7fef9cf7367233d7c88068fe6e34ed0d355a610d"
   integrity sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==
+
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
 
 call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.4, call-bind@^1.0.5:
   version "1.0.5"
@@ -4936,6 +4954,15 @@ dotenv@^16.3.1:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -5143,10 +5170,27 @@ es-abstract@^1.22.1:
     unbox-primitive "^1.0.2"
     which-typed-array "^1.1.13"
 
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
 es-module-lexer@^1.0.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.4.1.tgz#41ea21b43908fe6a287ffcbe4300f790555331f5"
   integrity sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
+  dependencies:
+    es-errors "^1.3.0"
 
 es-set-tostringtag@^2.0.1:
   version "2.0.2"
@@ -5156,6 +5200,16 @@ es-set-tostringtag@^2.0.1:
     get-intrinsic "^1.2.2"
     has-tostringtag "^1.0.0"
     hasown "^2.0.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 es-shim-unscopables@^1.0.0:
   version "1.0.2"
@@ -6110,6 +6164,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
   integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -6140,6 +6199,17 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+form-data@^4.0.5:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -6324,6 +6394,22 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
     has-symbols "^1.0.3"
     hasown "^2.0.0"
 
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
 get-port@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
@@ -6333,6 +6419,14 @@ get-port@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-6.1.2.tgz#c1228abb67ba0e17fb346da33b15187833b9c08a"
   integrity sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stream@^5.1.0:
   version "5.2.0"
@@ -6520,6 +6614,11 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 got@^12.0.0, got@^12.1.0, got@^12.3.1, got@^12.6.1:
   version "12.6.1"
   resolved "https://registry.yarnpkg.com/got/-/got-12.6.1.tgz#8869560d1383353204b5a9435f782df9c091f549"
@@ -6609,12 +6708,24 @@ has-symbols@^1.0.2, has-symbols@^1.0.3:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
+has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
 has-tostringtag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
   integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
   dependencies:
     has-symbols "^1.0.2"
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
 
 has-unicode@^2.0.1:
   version "2.0.1"
@@ -6688,6 +6799,13 @@ hasown@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
   integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.2, hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -6811,7 +6929,7 @@ http2-wrapper@^2.1.10:
     quick-lru "^5.1.1"
     resolve-alpn "^1.2.0"
 
-https-proxy-agent@5.0.1, https-proxy-agent@^5.0.0:
+https-proxy-agent@5.0.1, https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
@@ -8002,6 +8120,11 @@ matcher-collection@^1.0.0, matcher-collection@^1.1.1:
   dependencies:
     minimatch "^3.0.2"
 
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
 maxstache-stream@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/maxstache-stream/-/maxstache-stream-1.0.4.tgz#9c7f5cab7e5fdd2d90da86143b4e9631ea328040"
@@ -8116,7 +8239,7 @@ mime-db@1.52.0, mime-db@^1.28.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.35, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -9442,6 +9565,11 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 ps-list@^8.0.0:
   version "8.1.1"


### PR DESCRIPTION
## Summary

- Replace the removed Ghost `limit=all` behavior with automatic 100-post pagination that follows `meta.pagination.next` and pauses 100ms between pages.
- Upgrade `@tryghost/content-api` to 1.12.10 and request Content API version `v6.0`.
- Keep explicit `--limit`/`--page` as a one-request mode with preflight validation for valid limits and positive page numbers.
- Fail closed on malformed pagination metadata or cycles before any Algolia writes begin.
- Update user and agent documentation for the completed Ghost 6 behavior.

Closes #163

## Public-seam coverage

- CLI subprocess validation occurs before config loading or network activity.
- Default CLI flow constructs a Ghost 6 client, fetches every page, and passes the aggregated posts through the existing transform/save path.
- `fetchPosts(browsePosts, options)` covers page defaults, exact continuation metadata, ordered aggregation, the 100ms delay, stable filtering, explicit one-page mode, malformed responses, missing metadata, invalid continuations, cycles, and unchanged SDK error propagation.

## Verification

- Node 16.20.2: 25 focused package tests plus ESLint
- Node 18.20.8: 25 focused package tests plus ESLint
- `yarn test`
- `yarn lint`
- Frozen Yarn install
- `@tryghost/content-api` 1.12.10 with `v6.0` loaded under Node 16 and 18
- `npm pack --dry-run` confirmed the executable CLI and `lib/fetch-posts.js` publish boundary
- `git diff --check`

No live Ghost or Algolia credentials were used; external seams are mocked deterministically. Automatic indexing still retains posts in memory before transformation, matching the previous full-index workflow.