### PR TITLE
Locked public library contracts

### DIFF
--- a/packages/algolia-fragmenter/test/fragmenter.test.js
+++ b/packages/algolia-fragmenter/test/fragmenter.test.js
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 
-import transforms from '../index.js';
+import fragmenter from '../index.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
@@ -11,103 +11,157 @@ const readFixture = (fileName) => {
     return fs.readFileSync(path.join(testDirectory, `fixtures`, `${fileName}.html`), {encoding: `utf8`});
 };
 
-describe('Algolia Transforms', function () {
-    it('Can reduce fragments under headings correctly', function () {
-        let fragments = [
-            {
-                html: '<p>Before getting started, you\'ll need these global packages to be installed:</p>',
-                content: 'Before getting started, you\'ll need these global packages to be installed:',
-                headings: ['Pre-requisites'],
-                anchor: 'pre-requisites',
-                customRanking: {position: 1, heading: 80},
-                objectID: '931c35eda23999b8124728b4bf4979eb'
-            },
-            {
-                html: '<li><strong>A <a href="https://docs.ghost.org/faq/node-versions/">supported version</a> of <a href="https://nodejs.org" target="_blank" rel="nofollow noopener noreferrer">Node.js</a></strong> - Ideally installed via <a href="https://github.com/creationix/nvm#install-script" target="_blank" rel="nofollow noopener noreferrer">nvm</a></li>',
-                content: 'A supported version of Node.js - Ideally installed via nvm',
-                headings: ['Pre-requisites'],
-                anchor: 'pre-requisites',
+const createPost = (overrides = {}) => ({
+    id: 'post-1',
+    slug: 'getting-started',
+    url: 'https://example.com/getting-started/',
+    html: '<p>Introduction.</p>',
+    feature_image: 'https://example.com/getting-started.jpg',
+    title: 'Getting started',
+    tags: [],
+    authors: [],
+    ...overrides
+});
 
-                customRanking: {position: 2, heading: 80},
-                objectID: 'dcbe237f62a97a33e1a9d8880c577933'
-            },
-            {
-                html: '<li><strong><a href="https://yarnpkg.com/en/docs/install#alternatives-tab" target="_blank" rel="nofollow noopener noreferrer">Yarn</a></strong> - to manage all the packages</li>',
-                content: 'Yarn - to manage all the packages',
-                headings: ['Pre-requisites'],
-                anchor: 'pre-requisites',
+const fragmentPosts = (posts) => {
+    return fragmenter.transformToAlgoliaObject(posts).reduce(fragmenter.fragmentTransformer, []);
+};
 
-                customRanking: {position: 3, heading: 80},
-                objectID: '49e23962e997062e388a060735442633'
-            },
-            {
-                html: '<pre class="language-bash"><code class="language-bash">yarn global add knex-migrator grunt-cli ember-cli bower</code></pre>',
-                content: 'yarn global add knex-migrator grunt-cli ember-cli bower',
-                headings: ['Pre-requisites', 'The install these global packages'],
-                anchor: 'the-install-these-global-packages',
+describe('Algolia fragmenter public contracts', function () {
+    it('selects the exact Algolia record shape and projects tag and author relations', function () {
+        const posts = [createPost({
+            tags: [{id: 'tag-id', name: 'Guide', slug: 'guide', description: 'not indexed'}],
+            authors: [{id: 'author-id', name: 'Ada Lovelace', slug: 'ada', bio: 'not indexed'}],
+            excerpt: 'not indexed'
+        })];
 
-                customRanking: {position: 4, heading: 60},
-                objectID: 'b1a9a06228097949e1b9f0cfcb7fe352'
-            }
+        expect(fragmenter.transformToAlgoliaObject(posts)).toEqual([{
+            objectID: 'post-1',
+            slug: 'getting-started',
+            url: 'https://example.com/getting-started/',
+            html: '<p>Introduction.</p>',
+            image: 'https://example.com/getting-started.jpg',
+            title: 'Getting started',
+            tags: [{name: 'Guide', slug: 'guide'}],
+            authors: [{name: 'Ada Lovelace', slug: 'ada'}]
+        }]);
+    });
+
+    it('omits posts whose slug is ignored', function () {
+        const posts = [
+            createPost({id: 'ignored-id', slug: 'ignored'}),
+            createPost({id: 'kept-id', slug: 'kept', title: 'Kept post'})
         ];
 
-        let reducedFragments = fragments.reduce(transforms._testReduceFragmentsUnderHeadings, []);
-
-        // We start with 4 elements, and end up with 2
-        expect(reducedFragments).toHaveLength(2);
-        // The content gets merged to contain all 3 strings
-        expect(reducedFragments[0].content).toMatch(/getting started/);
-        expect(reducedFragments[0].content).toMatch(/supported version/);
-        expect(reducedFragments[0].content).toMatch(/manage all the packages/);
+        expect(fragmenter.transformToAlgoliaObject(posts, ['ignored'])).toEqual([{
+            objectID: 'kept-id',
+            slug: 'kept',
+            url: 'https://example.com/getting-started/',
+            html: '<p>Introduction.</p>',
+            image: 'https://example.com/getting-started.jpg',
+            title: 'Kept post',
+            tags: [],
+            authors: []
+        }]);
     });
 
-    it('Processes minimal example correctly', function () {
-        const fakeNode = {
-            objectID: `abc`,
-            title: `Install from Source`,
-            url: `/install/source/`,
-            html: readFixture(`minimal-example`)
-        };
-        let reducedFragments = transforms.fragmentTransformer([], fakeNode);
+    it('normalizes null and missing relations to empty projections', function () {
+        const postWithMissingRelations = createPost({id: 'missing-relations'});
+        delete postWithMissingRelations.tags;
+        delete postWithMissingRelations.authors;
 
-        expect(reducedFragments).toHaveLength(4);
-        expect(reducedFragments[1].url).toBe('/install/source/#pre-requisites');
+        const records = fragmenter.transformToAlgoliaObject([
+            createPost({id: 'null-relations', tags: null, authors: null}),
+            postWithMissingRelations
+        ]);
+
+        expect(records.map(({objectID, tags, authors}) => ({objectID, tags, authors}))).toEqual([
+            {objectID: 'null-relations', tags: [], authors: []},
+            {objectID: 'missing-relations', tags: [], authors: []}
+        ]);
     });
 
-    it('merges multiple nodes correctly', function () {
-        const fakeNodes = [{
-            objectID: `abc`,
-            title: `Install from Source`,
-            url: `/install/source/`,
-            html: readFixture(`minimal-example`)
-        }, {
-            objectID: `def`,
-            title: `Install Test`,
-            url: `/install/test/`,
-            html: `<p>I am a test</p><h2 id="testing">Testing</h1><p>I am a subtest</p>`
-        }];
+    it('creates one exact record for headingless content', function () {
+        const records = fragmentPosts([createPost({
+            id: 'headless',
+            slug: 'headless',
+            url: '/headless/',
+            html: '<p>First <em>paragraph</em>.</p><p>Second paragraph.</p>',
+            feature_image: null,
+            title: 'Headless'
+        })]);
 
-        let reducedFragments = fakeNodes.reduce(transforms.fragmentTransformer, []);
-
-        expect(reducedFragments).toHaveLength(6);
-        expect(reducedFragments[0].url).toBe('/install/source/');
-        expect(reducedFragments[1].url).toBe('/install/source/#pre-requisites');
-        expect(reducedFragments[4].url).toBe('/install/test/');
-        expect(reducedFragments[5].url).toBe('/install/test/#testing');
+        expect(records).toEqual([{
+            objectID: 'headless_0',
+            slug: 'headless',
+            url: '/headless/',
+            html: '<p>First <em>paragraph</em>.</p><p>Second paragraph.</p>',
+            image: null,
+            title: 'Headless',
+            tags: [],
+            authors: [],
+            headings: [],
+            anchor: null,
+            customRanking: {position: 0, heading: 100}
+        }]);
     });
 
-    it('Processes massive example correctly', function () {
-        const fakeNode = {
-            objectID: `abc`,
-            title: `Install from Source`,
-            url: `/install/source/`,
-            html: readFixture(`massive-example`)
-        };
+    it('preserves text but drops preformatted markup when merging a heading fragment', function () {
+        const records = fragmentPosts([createPost({
+            id: 'preformatted',
+            slug: 'preformatted',
+            url: '/preformatted/',
+            html: '<h2 id="commands">Commands</h2><p>Run:</p><pre><code>npm install ghost</code></pre><p>Then continue.</p>',
+            feature_image: null,
+            title: 'Preformatted'
+        })]);
 
-        let reducedFragments = [fakeNode].reduce(transforms.fragmentTransformer, []);
+        expect(records).toEqual([{
+            objectID: 'preformatted_0',
+            slug: 'preformatted',
+            url: '/preformatted/#commands',
+            html: '<p>Run:</p> npm install ghost<p>Then continue.</p>',
+            image: null,
+            title: 'Preformatted',
+            tags: [],
+            authors: [],
+            headings: ['Commands'],
+            anchor: 'commands',
+            customRanking: {position: 0, heading: 80}
+        }]);
+    });
 
-        reducedFragments.forEach((fragment) => {
-            expect(JSON.stringify(fragment).length).toBeLessThan(10000);
+    it('accumulates ordered fragments from every post', function () {
+        const records = fragmentPosts([
+            createPost({
+                id: 'first',
+                slug: 'first',
+                url: '/first/',
+                html: '<p>First post.</p>',
+                title: 'First'
+            }),
+            createPost({
+                id: 'second',
+                slug: 'second',
+                url: '/second/',
+                html: '<p>Second post.</p>',
+                title: 'Second'
+            })
+        ]);
+
+        expect(records.map(({objectID, slug, html}) => ({objectID, slug, html}))).toEqual([
+            {objectID: 'first_0', slug: 'first', html: '<p>First post.</p>'},
+            {objectID: 'second_0', slug: 'second', html: '<p>Second post.</p>'}
+        ]);
+    });
+
+    it('keeps every generated record below Algolia\'s object size limit', function () {
+        const records = fragmentPosts([createPost({
+            html: readFixture('massive-example')
+        })]);
+
+        records.forEach((record) => {
+            expect(JSON.stringify(record).length).toBeLessThan(10000);
         });
     });
 });

--- a/packages/algolia-indexer/test/IndexFactory.test.js
+++ b/packages/algolia-indexer/test/IndexFactory.test.js
@@ -1,89 +1,396 @@
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {afterAll, beforeAll, beforeEach, describe, expect, it} from 'vitest';
+import {createRequire} from 'node:module';
+import http from 'node:http';
+import https from 'node:https';
+import Module from 'node:module';
+import net from 'node:net';
+import tls from 'node:tls';
 
-import IndexFactory from '../index.js';
+const require = createRequire(import.meta.url);
+const requester = require('./helpers/algolia-requester-register.js');
+const packageEntryPath = require.resolve('../index.js');
+const indexFactoryPath = require.resolve('../lib/IndexFactory.js');
+const algoliaSearchPath = require.resolve('algoliasearch');
+const dependencyMarker = `${require.resolve('@algolia/requester-node-http').split('/@algolia/')[0]}/@algolia/`;
+const algoliaSearchMarker = `${algoliaSearchPath.slice(0, algoliaSearchPath.lastIndexOf('/'))}/`;
 
-describe('IndexFactory', function () {
-    let mockIndex;
+const isSubjectCacheEntry = (filename) => {
+    return filename === packageEntryPath
+        || filename === indexFactoryPath
+        || filename.startsWith(dependencyMarker)
+        || filename.startsWith(algoliaSearchMarker);
+};
 
-    beforeEach(function () {
-        // Mocking algoliasearch client and index
-        mockIndex = {
-            setSettings: vi.fn(),
-            getSettings: vi.fn(),
-            saveObjects: vi.fn(),
-            deleteBy: vi.fn(),
-            deleteObjects: vi.fn()
-        };
-    });
+const originalCacheEntries = new Map(Object.entries(require.cache).filter(([filename]) => isSubjectCacheEntry(filename)));
 
-    afterEach(function () {
-        vi.restoreAllMocks();
-    });
+const restoreSubjectCache = () => {
+    for (const filename of Object.keys(require.cache).filter(isSubjectCacheEntry)) {
+        delete require.cache[filename];
+    }
+    for (const [filename, cacheEntry] of originalCacheEntries) {
+        require.cache[filename] = cacheEntry;
+    }
+};
 
-    function createMockedAlgoliaIndex(settings) {
-        const algoliaIndex = new IndexFactory(settings);
+const clearSubjectCache = () => {
+    for (const filename of Object.keys(require.cache).filter(isSubjectCacheEntry)) {
+        delete require.cache[filename];
+    }
+};
 
-        // Immediately stub the initClient and initIndex methods after instantiation
-        vi.spyOn(algoliaIndex, 'initClient').mockImplementation(function () {
-            this.client = {}; // You can mock further if needed
-        });
+let IndexFactory;
 
-        vi.spyOn(algoliaIndex, 'initIndex').mockImplementation(async function () {
-            this.initClient();
-            this.index = mockIndex;
-        });
+const loadSubject = (load = () => require('../index.js')) => {
+    requester.install();
+    clearSubjectCache();
+    try {
+        IndexFactory = load();
+    } catch (error) {
+        restoreSubjectCache();
+        requester.restore();
+        throw error;
+    }
+};
 
-        return algoliaIndex;
+const expectOriginalCacheIdentities = () => {
+    const restoredEntries = new Map(Object.entries(require.cache).filter(([filename]) => isSubjectCacheEntry(filename)));
+    expect([...restoredEntries.keys()]).toEqual([...originalCacheEntries.keys()]);
+    for (const [filename, cacheEntry] of originalCacheEntries) {
+        expect(restoredEntries.get(filename)).toBe(cacheEntry);
+    }
+};
+
+const REQUIRED_SETTINGS = {
+    distinct: true,
+    attributeForDistinct: 'slug',
+    customRanking: ['desc(customRanking.heading)', 'asc(customRanking.position)'],
+    searchableAttributes: ['title', 'headings', 'html', 'url', 'tags.name', 'tags', 'authors.name', 'authors'],
+    attributesForFaceting: ['filterOnly(slug)']
+};
+
+const ALGOLIA_OPTIONS = {
+    appId: 'app-id',
+    apiKey: 'admin-api-key',
+    index: 'help-center'
+};
+
+const createIndexer = (overrides = {}) => {
+    return new IndexFactory({...ALGOLIA_OPTIONS, ...overrides});
+};
+
+const normalizeRequest = (request) => {
+    const url = new URL(request.url);
+    return {
+        method: request.method,
+        origin: url.origin,
+        pathname: url.pathname,
+        headers: request.headers,
+        body: request.data ? JSON.parse(request.data) : undefined
+    };
+};
+
+const exactMappedError = error => ({
+    name: error.name,
+    message: error.message,
+    errorType: error.errorType,
+    code: error.code,
+    status: error.status,
+    originalError: {
+        name: error.originalError.name,
+        message: error.originalError.message,
+        attempts: error.originalError.transporterStackTrace.map(({request, response}) => ({
+            method: request.method,
+            pathname: new URL(request.url).pathname,
+            body: request.data ? JSON.parse(request.data) : undefined,
+            response: {
+                status: response.status,
+                content: response.content,
+                isTimedOut: response.isTimedOut
+            }
+        }))
+    },
+    enumerableFields: Object.keys(error).sort()
+});
+
+const assertMappedOperationError = async (invoke, expectedAttempt) => {
+    const indexer = createIndexer();
+    await indexer.initIndex();
+    requester.reset({status: 503, message: 'Algolia is unavailable'});
+
+    let error;
+    try {
+        await invoke(indexer);
+    } catch (operationError) {
+        error = operationError;
     }
 
-    it('throws error when settings are not passed', function () {
+    expect(exactMappedError(error)).toEqual({
+        name: 'Error',
+        message: 'Unreachable hosts - your application id may be incorrect. If the error persists, contact support@algolia.com.',
+        errorType: 'AlgoliaError',
+        code: undefined,
+        status: undefined,
+        originalError: {
+            name: 'RetryError',
+            message: 'Unreachable hosts - your application id may be incorrect. If the error persists, contact support@algolia.com.',
+            attempts: Array(4).fill({
+                ...expectedAttempt,
+                response: {
+                    status: 503,
+                    content: '{"message":"Algolia is unavailable"}',
+                    isTimedOut: false
+                }
+            })
+        },
+        enumerableFields: ['code', 'errorType', 'originalError']
+    });
+};
+
+describe('IndexFactory public contracts', function () {
+    beforeAll(function () {
+        loadSubject();
+    });
+
+    afterAll(function () {
+        restoreSubjectCache();
+        requester.restore();
+    });
+
+    beforeEach(function () {
+        requester.reset();
+    });
+
+    it('requires an application ID, API key, and index name', function () {
+        expect(() => new IndexFactory()).toThrow('Algolia appId, apiKey, and index is required!');
+    });
+
+    it('denies bypass network access and restores every hook and cache identity', function () {
+        const originals = requester.originals();
+        expect(() => http.request('http://example.com')).toThrow('denied an unexpected network request');
+        expect(() => https.get('https://example.com')).toThrow('denied an unexpected network request');
+        expect(() => net.connect(443, 'example.com')).toThrow('denied an unexpected network request');
+        expect(() => tls.connect(443, 'example.com')).toThrow('denied an unexpected network request');
+        expect(() => global.fetch('https://example.com')).toThrow('denied an unexpected network request');
+
         try {
-            createMockedAlgoliaIndex();
-            throw new Error('Expected IndexFactory construction to fail.');
-        } catch (error) {
-            expect(error.message).toBe('Algolia appId, apiKey, and index is required!');
+            restoreSubjectCache();
+            requester.restore();
+
+            expect(Module._load).toBe(originals.load);
+            expect(http.request).toBe(originals.httpRequest);
+            expect(http.get).toBe(originals.httpGet);
+            expect(https.request).toBe(originals.httpsRequest);
+            expect(https.get).toBe(originals.httpsGet);
+            expect(net.connect).toBe(originals.netConnect);
+            expect(net.createConnection).toBe(originals.netCreateConnection);
+            expect(net.Socket.prototype.connect).toBe(originals.socketConnect);
+            expect(tls.connect).toBe(originals.tlsConnect);
+            expect(global.fetch).toBe(originals.fetch);
+            expectOriginalCacheIdentities();
+        } finally {
+            loadSubject();
         }
     });
 
-    describe('setSettingsForIndex', function () {
-        it('updates settings by default', async function () {
-            const algoliaIndex = await createMockedAlgoliaIndex({appId: 'test', apiKey: 'test', index: 'ALGOLIA'});
+    it('restores hooks and cache identities when subject loading fails', function () {
+        const originals = requester.originals();
 
-            mockIndex.getSettings.mockResolvedValue({some: 'settings'}); // Provide a mocked response for getSettings
+        try {
+            expect(() => loadSubject(() => {
+                throw new Error('synthetic subject import failure');
+            })).toThrow('synthetic subject import failure');
 
-            const settings = await algoliaIndex.setSettingsForIndex();
+            expect(Module._load).toBe(originals.load);
+            expect(http.request).toBe(originals.httpRequest);
+            expect(https.request).toBe(originals.httpsRequest);
+            expect(net.connect).toBe(originals.netConnect);
+            expect(tls.connect).toBe(originals.tlsConnect);
+            expect(global.fetch).toBe(originals.fetch);
+            expectOriginalCacheIdentities();
+        } finally {
+            loadSubject();
+        }
+    });
 
-            expect(mockIndex.setSettings).toHaveBeenCalled();
-            expect(mockIndex.getSettings).toHaveBeenCalled();
+    it('initializes the exact external application and index', async function () {
+        const indexer = createIndexer();
 
-            expect(settings).not.toBeNull();
-            expect(settings).toEqual({some: 'settings'});
-        });
+        indexer.initClient();
+        await indexer.initIndex();
+        await indexer.index.getSettings();
 
-        it('does not update Algolia settings when set to false', async function () {
-            const algoliaIndex = await createMockedAlgoliaIndex({appId: 'test', apiKey: 'test', index: 'ALGOLIA'});
+        expect(requester.requests().map(normalizeRequest)).toEqual([{
+            method: 'GET',
+            origin: 'https://app-id-dsn.algolia.net',
+            pathname: '/1/indexes/help-center/settings',
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded',
+                'x-algolia-api-key': 'admin-api-key',
+                'x-algolia-application-id': 'app-id'
+            },
+            body: undefined
+        }]);
+    });
 
-            mockIndex.getSettings.mockResolvedValue({some: 'settings'}); // Provide a mocked response for getSettings
+    it('applies the required settings by default and returns the external settings', async function () {
+        const settings = await createIndexer().setSettingsForIndex();
 
-            const settings = await algoliaIndex.setSettingsForIndex({updateSettings: false});
-
-            expect(mockIndex.setSettings).not.toHaveBeenCalled();
-            expect(mockIndex.getSettings).toHaveBeenCalled();
-
-            expect(settings).not.toBeNull();
-            expect(settings).toEqual({some: 'settings'});
-        });
-
-        it('throws AlgoliaError when an error occurs', async function () {
-            const algoliaIndex = await createMockedAlgoliaIndex({appId: 'test', apiKey: 'test', index: 'ALGOLIA'});
-
-            mockIndex.getSettings.mockRejectedValue(new Error('Test Error')); // Simulating an error
-
-            await expect(algoliaIndex.setSettingsForIndex()).rejects.toMatchObject({
-                errorType: 'AlgoliaError'
-            });
+        expect({requests: requester.requests().map(normalizeRequest), settings}).toEqual({
+            requests: [
+                {
+                    method: 'PUT',
+                    origin: 'https://app-id.algolia.net',
+                    pathname: '/1/indexes/help-center/settings',
+                    headers: {
+                        'content-type': 'application/x-www-form-urlencoded',
+                        'x-algolia-api-key': 'admin-api-key',
+                        'x-algolia-application-id': 'app-id'
+                    },
+                    body: REQUIRED_SETTINGS
+                },
+                {
+                    method: 'GET',
+                    origin: 'https://app-id-dsn.algolia.net',
+                    pathname: '/1/indexes/help-center/settings',
+                    headers: {
+                        'content-type': 'application/x-www-form-urlencoded',
+                        'x-algolia-api-key': 'admin-api-key',
+                        'x-algolia-application-id': 'app-id'
+                    },
+                    body: undefined
+                }
+            ],
+            settings: {distinct: true}
         });
     });
 
-    // TODO: Add tests for the other methods like save, delete, deleteObjects, etc.
+    it('applies custom settings when updates are explicitly enabled', async function () {
+        const customSettings = {searchableAttributes: ['title', 'html']};
+
+        await createIndexer({indexSettings: customSettings}).setSettingsForIndex({updateSettings: true});
+
+        expect(requester.requests().map(normalizeRequest).map(({method, pathname, body}) => ({method, pathname, body}))).toEqual([
+            {method: 'PUT', pathname: '/1/indexes/help-center/settings', body: customSettings},
+            {method: 'GET', pathname: '/1/indexes/help-center/settings', body: undefined}
+        ]);
+    });
+
+    it('reads settings without applying them when updates are explicitly disabled', async function () {
+        const settings = await createIndexer().setSettingsForIndex({updateSettings: false});
+
+        expect({requests: requester.requests().map(normalizeRequest), settings}).toEqual({
+            requests: [{
+                method: 'GET',
+                origin: 'https://app-id-dsn.algolia.net',
+                pathname: '/1/indexes/help-center/settings',
+                headers: {
+                    'content-type': 'application/x-www-form-urlencoded',
+                    'x-algolia-api-key': 'admin-api-key',
+                    'x-algolia-application-id': 'app-id'
+                },
+                body: undefined
+            }],
+            settings: {distinct: true}
+        });
+    });
+
+    it('serializes the exact records for saving', async function () {
+        const indexer = createIndexer();
+        const records = [{objectID: 'post-1_0'}, {objectID: 'post-1_1'}];
+        await indexer.initIndex();
+
+        await indexer.save(records);
+
+        expect(requester.requests().map(normalizeRequest)).toEqual([{
+            method: 'POST',
+            origin: 'https://app-id.algolia.net',
+            pathname: '/1/indexes/help-center/batch',
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded',
+                'x-algolia-api-key': 'admin-api-key',
+                'x-algolia-application-id': 'app-id'
+            },
+            body: {
+                requests: [
+                    {action: 'updateObject', body: {objectID: 'post-1_0'}},
+                    {action: 'updateObject', body: {objectID: 'post-1_1'}}
+                ]
+            }
+        }]);
+    });
+
+    it('serializes the exact slug filter for deletion', async function () {
+        const indexer = createIndexer();
+        await indexer.initIndex();
+
+        await indexer.delete('getting-started');
+
+        expect(requester.requests().map(normalizeRequest)).toEqual([{
+            method: 'POST',
+            origin: 'https://app-id.algolia.net',
+            pathname: '/1/indexes/help-center/deleteByQuery',
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded',
+                'x-algolia-api-key': 'admin-api-key',
+                'x-algolia-application-id': 'app-id'
+            },
+            body: {filters: 'slug:getting-started'}
+        }]);
+    });
+
+    it('serializes the exact object IDs for deletion', async function () {
+        const indexer = createIndexer();
+        await indexer.initIndex();
+
+        await indexer.deleteObjects(['post-1_0', 'post-1_1']);
+
+        expect(requester.requests().map(normalizeRequest)).toEqual([{
+            method: 'POST',
+            origin: 'https://app-id.algolia.net',
+            pathname: '/1/indexes/help-center/batch',
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded',
+                'x-algolia-api-key': 'admin-api-key',
+                'x-algolia-application-id': 'app-id'
+            },
+            body: {
+                requests: [
+                    {action: 'deleteObject', body: {objectID: 'post-1_0'}},
+                    {action: 'deleteObject', body: {objectID: 'post-1_1'}}
+                ]
+            }
+        }]);
+    });
+
+    it('maps setSettingsForIndex failures to the exact AlgoliaError fields', async function () {
+        await assertMappedOperationError(indexer => indexer.setSettingsForIndex(), {
+            method: 'PUT',
+            pathname: '/1/indexes/help-center/settings',
+            body: REQUIRED_SETTINGS
+        });
+    });
+
+    it('maps save failures to the exact AlgoliaError fields', async function () {
+        await assertMappedOperationError(indexer => indexer.save([{objectID: 'post-1_0'}]), {
+            method: 'POST',
+            pathname: '/1/indexes/help-center/batch',
+            body: {requests: [{action: 'updateObject', body: {objectID: 'post-1_0'}}]}
+        });
+    });
+
+    it('maps delete failures to the exact AlgoliaError fields', async function () {
+        await assertMappedOperationError(indexer => indexer.delete('getting-started'), {
+            method: 'POST',
+            pathname: '/1/indexes/help-center/deleteByQuery',
+            body: {filters: 'slug:getting-started'}
+        });
+    });
+
+    it('maps deleteObjects failures to the exact AlgoliaError fields', async function () {
+        await assertMappedOperationError(indexer => indexer.deleteObjects(['post-1_0']), {
+            method: 'POST',
+            pathname: '/1/indexes/help-center/batch',
+            body: {requests: [{action: 'deleteObject', body: {objectID: 'post-1_0'}}]}
+        });
+    });
 });

--- a/packages/algolia-indexer/test/helpers/algolia-requester-register.js
+++ b/packages/algolia-indexer/test/helpers/algolia-requester-register.js
@@ -1,0 +1,109 @@
+const http = require('node:http');
+const https = require('node:https');
+const Module = require('node:module');
+const net = require('node:net');
+const tls = require('node:tls');
+
+const originals = {
+    load: Module._load,
+    httpRequest: http.request,
+    httpGet: http.get,
+    httpsRequest: https.request,
+    httpsGet: https.get,
+    netConnect: net.connect,
+    netCreateConnection: net.createConnection,
+    socketConnect: net.Socket.prototype.connect,
+    tlsConnect: tls.connect,
+    fetch: global.fetch
+};
+const state = {failure: null, installed: false, requests: []};
+
+const denyNetwork = transport => () => {
+    throw new Error(`${transport} denied an unexpected network request.`);
+};
+
+const responseFor = (request, requestNumber) => {
+    if (state.failure) {
+        return {
+            status: state.failure.status,
+            content: JSON.stringify({message: state.failure.message}),
+            isTimedOut: false
+        };
+    }
+
+    const pathname = new URL(request.url).pathname;
+    if (request.method === 'GET' && pathname.endsWith('/settings')) {
+        return {
+            status: 200,
+            content: JSON.stringify({distinct: true}),
+            isTimedOut: false
+        };
+    }
+
+    return {
+        status: 200,
+        content: JSON.stringify({taskID: requestNumber, objectIDs: []}),
+        isTimedOut: false
+    };
+};
+
+const createNodeHttpRequester = () => ({
+    async send(request) {
+        state.requests.push(structuredClone(request));
+        return responseFor(request, state.requests.length);
+    },
+    async destroy() {}
+});
+
+const mockedLoad = function (request) {
+    if (request === '@algolia/requester-node-http') {
+        return {createNodeHttpRequester};
+    }
+    return originals.load.apply(this, arguments);
+};
+
+const install = () => {
+    if (state.installed) {
+        return;
+    }
+    state.installed = true;
+    Module._load = mockedLoad;
+    http.request = denyNetwork('http.request');
+    http.get = denyNetwork('http.get');
+    https.request = denyNetwork('https.request');
+    https.get = denyNetwork('https.get');
+    net.connect = denyNetwork('net.connect');
+    net.createConnection = denyNetwork('net.createConnection');
+    net.Socket.prototype.connect = denyNetwork('net.Socket.connect');
+    tls.connect = denyNetwork('tls.connect');
+    global.fetch = denyNetwork('fetch');
+};
+
+const restore = () => {
+    Module._load = originals.load;
+    http.request = originals.httpRequest;
+    http.get = originals.httpGet;
+    https.request = originals.httpsRequest;
+    https.get = originals.httpsGet;
+    net.connect = originals.netConnect;
+    net.createConnection = originals.netCreateConnection;
+    net.Socket.prototype.connect = originals.socketConnect;
+    tls.connect = originals.tlsConnect;
+    global.fetch = originals.fetch;
+    state.installed = false;
+};
+
+module.exports = {
+    install,
+    restore,
+    reset(failure = null) {
+        state.failure = failure;
+        state.requests.length = 0;
+    },
+    requests() {
+        return structuredClone(state.requests);
+    },
+    originals() {
+        return {...originals};
+    }
+};

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -6,6 +6,12 @@ export default defineConfig({
             provider: 'custom',
             customProviderModule: './test/coverage-provider.mjs',
             reporter: ['text', 'json-summary', 'lcov'],
+            thresholds: {
+                statements: 93,
+                branches: 90,
+                functions: 96,
+                lines: 93
+            },
             include: [
                 'packages/*/index.js',
                 'packages/*/lib/**/*.js',


### PR DESCRIPTION
## What changed

- add public-entry contract coverage for fragment projection, ignored slugs, relations, content edges, size limits, and ordered multi-post accumulation
- exercise the real Algolia SDK through `IndexFactory`, replacing only its external HTTP requester
- cover exact index initialization, settings, save, slug deletion, object deletion, retries, and mapped error behavior
- enforce global coverage thresholds at 93% statements, 90% branches, 96% functions, and 93% lines

## Boundary and mocks

Tests call the published fragmenter and indexer entrypoints. The Algolia SDK remains real; only `@algolia/requester-node-http` is intercepted. Unexpected HTTP, HTTPS, fetch, TCP, and TLS access is denied, and every patched loader/network identity is restored after success or import failure.

Netlify deployment builds remain covered by Netlify deploy-preview checks and are not duplicated here.

## Verification

- 101 tests
- 94.15% statements / 91.02% branches / 97.22% functions / 94.07% lines
- five serial coverage runs produced identical totals
- focused fragmenter and indexer suites
- frozen Node 24 install
- root tests, coverage, typecheck, and lint
- mutation checks for record projection, multi-post accumulation, delete filters, error mapping, and coverage thresholds
- no production files changed
