### PR TITLE
Add stable required checks gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,16 @@ jobs:
       - run: yarn test:coverage
       - run: yarn typecheck
       - run: yarn lint
+
+  required-checks-pass:
+    name: Required checks pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success")' > /dev/null


### PR DESCRIPTION
## Summary

- add a `required-checks-pass` aggregator with the stable `Required checks pass` status name
- run the gate after `test` even when the upstream job fails or is skipped
- fail closed unless every needed job reports `success`
- preserve the existing Node 24 validation job and read-only workflow permissions

## Verification

- `actionlint .github/workflows/test.yml`
- parsed the workflow and asserted the exact job contract, dependency, permissions, and unchanged `test` job
- exercised the gate expression with success, failure, cancelled, skipped, unknown, empty, and null job results
- `git diff --check`
