### PR TITLE
Standardized Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "@tryghost:quietJS"
+    "local>TryGhost/renovate-config"
   ]
 }


### PR DESCRIPTION
## Why

Standardize this repository on the shared TryGhost Renovate policy now that its pull-request validation is trustworthy enough for the default preset.

## Configuration decision

- Applied `local>TryGhost/renovate-config` from the root `renovate.json`.
- High-CI-trust evidence on merged `main`: Node 24 runs frozen installs, threshold-enforced coverage, strict TypeScript checks, and linting; `Required checks pass` provides a stable fail-closed aggregate gate. The suite includes the Ghost Content API pagination, public package contracts, CLI behavior, and native Netlify webhook boundary.
- Previous location: root `renovate.json`.
- New location: root `renovate.json`; no config relocation was needed.
- Added the official Renovate schema reference.
- No `package.json` Renovate key existed, so none was removed.

## Retained and dropped configuration

- Dropped the legacy `@tryghost:quietJS` preset in favor of the canonical shared default preset. It was the only prior override.
- Retained no local overrides because there were no repository-specific `automerge`, schedule, timezone, manager, host/auth, or `packageRules` settings to preserve.
- Added no runtime or package-manager rules. `.nvmrc` intentionally floats on Node 24, CI reads that floating major, package engines remain `>=24`, and no package manager is pinned. This is not an exact-patch runtime repository, so Renovate should not reject Node 25 or otherwise constrain Node updates locally.
- Existing Renovate pull requests and the dependency dashboard were not changed.

## Verification

- `jq` parse and exact-shape assertion
- `npx --yes --package renovate@43.262.2 renovate-config-validator --strict --no-global renovate.json`
- Node 24: `yarn install --frozen-lockfile --non-interactive`
- Node 24: `yarn test` — 101 tests plus typecheck and lint passed
- one-file scope assertion and `git diff --check`
