### PR TITLE
Updated Netlify package documentation

### DIFF
--- a/packages/algolia-netlify/README.md
+++ b/packages/algolia-netlify/README.md
@@ -86,7 +86,7 @@ Run the full monorepo suite with `pnpm test`.
 
 The modern handlers use native `Request` and `Response` objects. Malformed, empty, or structurally invalid JSON now receives `400 Invalid request body`; a valid Ghost envelope with no selected post remains a `200 No valid request body detected` response. Existing valid webhook behavior, endpoint URLs, and optional `key` handling are unchanged.
 
-`pnpm pack` builds an ESM-only Node 24 package with generated TypeScript declarations. The package intentionally exposes only the two handlers; webhook utilities remain internal.
+From this package directory, `pnpm pack` builds an ESM-only package with generated TypeScript declarations. The supported Node range is declared in [`package.json`](package.json). The package intentionally exposes only the two handlers; webhook utilities remain internal.
 
 ---
 


### PR DESCRIPTION
## What changed

- Clarified that `pnpm pack` should be run from `packages/algolia-netlify`.
- Pointed the supported Node range at the package's `package.json` instead of repeating a version in prose.

## Why

The previous sentence could be read as a root-level command and duplicated runtime information that can drift from the package metadata.

## Impact

Documentation only. No package, runtime, API, record-shape, CLI, or webhook behavior changes.

## Validation

- `git diff --check`
