### PR TITLE
Document HTML extractor planning decisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# Ghost Algolia
+
+Ghost Algolia turns published Ghost content into structured records for an Algolia search index.
+
+## Language
+
+**Ghost content**:
+A published post or page returned by the Ghost Content API, including its metadata and rendered HTML.
+_Avoid_: Page, document, article when the resource type is not important
+
+**Post projection**:
+The selected Ghost content fields that are carried into every Algolia record derived from that content.
+_Avoid_: Base record, Algolia post
+
+**Extraction fragment**:
+An ordered unit of rendered HTML associated with its current heading path, anchor, and position.
+_Avoid_: Chunk, paragraph record
+
+**HTML extractor**:
+The component that converts rendered HTML into ordered extraction fragments.
+_Avoid_: Fragmenter, transformer
+
+**Fragmenter**:
+The component that groups extraction fragments and combines them with a post projection to produce Algolia records.
+_Avoid_: HTML extractor
+
+**Algolia record**:
+The final indexed object containing projected Ghost fields, grouped extracted content, and ranking metadata.
+_Avoid_: Extraction fragment, Algolia post
+
+**Ghost-rendered fixture**:
+An immutable Content API response produced by Ghost from controlled source content and retained as deterministic test evidence.
+_Avoid_: Mock response, live fixture
+
+**Live content smoke test**:
+A non-blocking check against a changing Ghost site that detects contract or structural drift without asserting exact editorial content.
+_Avoid_: Acceptance test, fixture test

--- a/docs/research/algolia-record-size-constraints.md
+++ b/docs/research/algolia-record-size-constraints.md
@@ -1,0 +1,77 @@
+# Algolia record-size constraints
+
+Status: researched against live official Algolia documentation on 2026-08-13.
+
+## Decision summary
+
+Ghost's deterministic size policy should target the strictest current generally available limit: every complete record, after compact JSON serialization, must be **less than 10,000 UTF-8 bytes**. This keeps the public packages usable on Algolia's free Build plan and is conservative across Algolia's undocumented `KB` boundary convention.
+
+This is a compatibility target chosen by Ghost, not a claim that all Algolia plans have a 10 KB per-record limit. Paid online plans currently allow larger individual records but add an average-size constraint. The configured Algolia plan must therefore remain irrelevant to extraction correctness; a paid plan should not be required to accept Ghost output.
+
+## Current official limits
+
+Algolia's current service-limit summary gives a plan-dependent range of 10 KB to 100 KB and identifies 10 KB as the free-plan maximum. Its more detailed support article distinguishes the online and legacy plans:
+
+| Plan | Individual-record maximum | Additional constraint |
+| --- | ---: | --- |
+| Free (the current pricing page calls this Build) | 10 KB | None documented |
+| Paid online plans | 100 KB | 10 KB average across all records |
+| Legacy Pro, Starter, or Free plans from before 2020-07-01 | 10 KB | None documented |
+| Legacy Essential or Plus plans from before 2020-07-01 | 20 KB | None documented |
+
+Committed subscriptions or service orders may differ, so these are public-plan defaults rather than a universal account contract. Algolia does not document in these sources whether `KB` means 1,000 or 1,024 bytes, nor how it enforces the paid-plan 10 KB average. Those facts must not be invented by the package.
+
+Sources: [Algolia service limits](https://www.algolia.com/doc/guides/scaling/algolia-service-limits), [Algolia record and index size limits](https://support.algolia.com/hc/en-us/articles/4406981897617-Is-there-a-size-limit-for-my-index-records), and [Algolia pricing](https://www.algolia.com/pricing).
+
+## What counts toward record size
+
+Algolia describes its calculation as stringifying the JSON input, removing whitespace outside key and value strings that is not syntactically necessary, parsing it again, and applying the limit to that final JSON. Consequently:
+
+- Measure the **whole record**, not only `html` or another large value. Attribute names, values, `objectID`, nested objects and arrays, JSON punctuation, escaping, and spaces inside strings all remain in the compact representation.
+- Formatting whitespace outside strings is irrelevant. `JSON.stringify(record)` produces the appropriate compact representation for this repository's plain JSON records.
+- JavaScript's `JSON.stringify(record).length` counts UTF-16 code units, not bytes. It can undercount non-ASCII Ghost content. The repository-compatible measurement is `Buffer.byteLength(JSON.stringify(record), 'utf8')`.
+- Algolia does not name the character encoding used by its size check. UTF-8 is the wire encoding for JSON sent by this Node client and is the conservative, reproducible local definition to adopt.
+
+The strict `< 10_000` target intentionally leaves the exact 10 KB boundary unused. A larger engineering safety margin may be chosen by the follow-on policy ticket, but it should be expressed separately from Algolia's documented limit.
+
+Source: [Algolia record and index size limits](https://support.algolia.com/hc/en-us/articles/4406981897617-Is-there-a-size-limit-for-my-index-records).
+
+## Searchable and stored attributes
+
+Algolia advises sending only attributes needed for search, display, sorting, filtering, or relevance. `searchableAttributes` controls which submitted attributes are searched; it does not remove other attributes from the submitted record. Similarly, `attributesToRetrieve` and `unretrievableAttributes` control search responses, not the JSON record accepted at indexing time. They therefore must not be treated as record-size exemptions.
+
+For Ghost, fields duplicated into every extraction fragment—currently `slug`, `url`, `image`, `title`, projected `tags` and `authors`, `headings`, `anchor`, `customRanking`, and `objectID`—consume part of every record's budget before `html` is added. Any future projected field consumes budget whether or not it is searchable.
+
+Sources: [Prepare records for indexing](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data), [Reduce record size](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/reducing-object-size), and [`unretrievableAttributes`](https://www.algolia.com/doc/api-reference/api-parameters/unretrievableAttributes).
+
+## Failure and batching behaviour
+
+When an individual record exceeds its plan's maximum, Algolia documents the API error as `Record is too big`; framework documentation also shows the more diagnostic form `Record at the position XX objectID=XX is too big`. Algolia recommends removing unnecessary attributes or splitting long documents into smaller records and using `distinct` to present the best matching part.
+
+This is separate from request-body size. Algolia currently permits an indexing request body up to 1 GB but recommends batches around 10 MB. A legal batch can therefore still contain an illegal record, and reducing the number of records in a batch does not make that record valid.
+
+The repository's `@tryghost/algolia-indexer` uses `algoliasearch@4.20.0` and calls `saveObjects(fragments)` once. That installed client sends sequential batches of 1,000 records. The indexer wraps any rejection as one `AlgoliaError`; it does not preflight sizes or identify a record itself. Because earlier batches can already have received task IDs before a later batch rejects, callers must not assume a failed multi-batch `saveObjects` call left the index untouched. The official material reviewed here does not establish batch-level atomicity when one record is oversized, so no stronger guarantee should enter the design.
+
+Sources: [Reduce record size](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/reducing-object-size), [Save records](https://www.algolia.com/doc/libraries/sdk/methods/search/save-objects), [Batch indexing operations](https://www.algolia.com/doc/rest-api/search/batch), and [Sending records in batches](https://www.algolia.com/doc/guides/sending-and-managing-data/send-and-update-your-data/how-to/sending-records-in-batches).
+
+## Repository findings
+
+- `packages/algolia-fragmenter/test/fragmenter.test.js` currently asserts `JSON.stringify(record).length < 10000`. Its threshold is directionally correct for the free plan, but its character count is not the required UTF-8 byte count.
+- `packages/algolia-fragmenter/lib/transformer.js` groups extracted elements by heading anchor. It does not enforce a byte budget, so a long headingless post or a long section can still exceed the limit.
+- The CLI documentation acknowledges this and currently tells operators to exclude oversized posts. That is operational fallback, not deterministic record-size handling.
+- `packages/algolia-indexer/lib/IndexFactory.js` makes `html` searchable and uses `slug` for distinctness and filtering. Splitting is compatible with the current search model provided every split retains the fields needed by distinctness, ranking, display, filtering, and stable updates.
+- The reviewed Ghost 6 golden fixture contains 101 records ranging from 410 to 717 compact UTF-8 bytes, averaging about 475 bytes. The existing `massive-example.html` fixture produces seven records with a maximum of 2,511 bytes. Neither fixture exercises the actual boundary or a non-ASCII character/byte mismatch.
+
+## Constraints for the follow-on design
+
+The record-size policy should therefore:
+
+1. validate the final projected Algolia record, not an extraction fragment or its HTML alone;
+2. use compact UTF-8 byte size and a strict free-plan-compatible ceiling;
+3. reserve space for metadata before allocating content bytes;
+4. split deterministically rather than silently truncate or require operators to skip a post;
+5. preserve the fields and ordering needed by `distinct`, ranking, deep links, display, deletion, and stable `objectID` generation;
+6. cover multi-byte text, JSON escaping, metadata-heavy records, headingless documents, and an exact near-boundary case in offline tests; and
+7. report an actionable local error only when an indivisible value or required metadata cannot fit, before calling Algolia.
+
+The exact safety margin, splitting unit, and stable ID scheme remain decisions for [Define deterministic Algolia record-size behaviour](https://github.com/TryGhost/algolia/issues/198). This research establishes their external constraints; it does not choose those behaviours.

--- a/docs/research/configurable-index-settings-defect.md
+++ b/docs/research/configurable-index-settings-defect.md
@@ -1,0 +1,83 @@
+# Configurable index-settings defect
+
+Date: 2026-08-13
+Decision ticket: [Narrow the configurable index-settings defect](https://github.com/TryGhost/algolia/issues/195)
+Original report: [Searchable attributes in the config file are not added to algolia](https://github.com/TryGhost/algolia/issues/23)
+
+## Decision
+
+Close the original report as stale and superseded rather than implementing its proposed coupling between configuration and record construction.
+
+The CLI already passes `algolia.indexSettings` from its JSON configuration to `IndexFactory`, and `IndexFactory` sends that object to Algolia. The remaining reproducible defect is narrower and belongs to the Netlify publish path: every `post-published` webhook constructs an indexer without custom settings and calls `setSettingsForIndex()`, so each publish reapplies the package defaults before it writes records. This is the behavior reported in the 2023 follow-up on the original issue, but it is not the issue title's claimed CLI defect.
+
+The fix should make settings writes explicit and single-owner:
+
+- The CLI owns initial index configuration during a batch index. It applies the configured settings patch when `algolia.indexSettings` is present, or the package defaults when it is absent, before adding records.
+- The Netlify webhooks own incremental record synchronization only. `post-published` should initialize the index and save records without reading or writing settings, matching `post-unpublished`, which already initializes the index directly before deleting records.
+- `@tryghost/algolia-indexer` remains the reusable mechanism for both operations: `initIndex()` establishes the client/index connection, `setSettingsForIndex()` is an explicit configuration operation, and `save()`/`delete()` never alter settings themselves.
+- Search relevance policy remains user-owned. `searchableAttributes`, its ordering, extra facets, and any additional ranking policy can be managed through the CLI config, Algolia dashboard, or Algolia API. Record projection remains a separate fragmenter concern: configuring an attribute cannot make it searchable unless the records actually contain it.
+
+## Current behavior
+
+### CLI: the original report is no longer reproducible
+
+The CLI loads the JSON object into `context`, constructs `IndexFactory(context.algolia)`, calls `setSettingsForIndex()`, and only then saves fragments ([CLI source](../../packages/algolia/bin/cli.js)). The constructor keeps a supplied `algolia.indexSettings` object and falls back to its defaults only when no object was supplied; `setSettingsForIndex()` sends that selected object to Algolia ([indexer source](../../packages/algolia-indexer/lib/IndexFactory.js)).
+
+The public-seam tests corroborate the contract:
+
+- the indexer test sends `{searchableAttributes: ['title', 'html']}` and asserts that exact object is the settings request ([indexer contract test](../../packages/algolia-indexer/test/IndexFactory.test.js));
+- the CLI acceptance test asserts that the settings body from its config fixture is sent before the record batch ([CLI acceptance test](../../packages/algolia/test/cli-ghost-v6.acceptance.test.js)).
+
+Algolia's `setSettings` contract is a partial update: specified settings are overridden and unspecified settings remain unchanged. It requires the `editSettings` ACL and returns an asynchronous task identifier. Therefore the existing custom object is a settings patch, not necessarily a complete desired-state document. [Algolia: update index settings](https://www.algolia.com/doc/libraries/sdk/methods/search/set-settings)
+
+### Netlify: a publish event still rewrites settings
+
+The Netlify environment adapter provides only application ID, API key, and index name ([webhook utility](../../packages/algolia-netlify/functions/utils/webhook.ts)). With no `indexSettings`, the indexer chooses its package defaults. `post-published` then calls `setSettingsForIndex()` before every `save()` ([publish handler](../../packages/algolia-netlify/functions/post-published.mts)). Its acceptance test freezes the current request sequence as settings `PUT`, settings `GET`, then records batch ([Netlify acceptance test](../../packages/algolia-netlify/test/handlers.acceptance.test.ts)).
+
+This means an operator can configure custom searchable attributes or facets through the dashboard/API and later have the package-owned keys reset by an unrelated post webhook. Algolia explicitly supports managing searchable attributes through either the dashboard or API, and their order affects ranking. [Algolia: searchable attributes](https://www.algolia.com/doc/guides/managing-results/must-do/searchable-attributes)
+
+`post-unpublished` already demonstrates the desired ownership boundary: it calls `initIndex()` and then deletes records without a settings call ([unpublish handler](../../packages/algolia-netlify/functions/post-unpublished.mts)).
+
+## Required settings versus user policy
+
+The constant currently named `REQUIRED_SETTINGS` mixes one operational prerequisite with search-experience defaults:
+
+| Setting | Contract classification | Reason |
+| --- | --- | --- |
+| `attributesForFaceting: ['filterOnly(slug)']` | Operational prerequisite while deletion uses `deleteBy({filters: 'slug:...'})` | Algolia requires a `deleteBy` filter attribute to be declared in `attributesForFaceting`; `filterOnly` is the appropriate modifier when facet counts are not needed. [Algolia: delete by](https://www.algolia.com/doc/libraries/sdk/v1/methods/delete-by) and [declare attributes for faceting](https://www.algolia.com/doc/guides/managing-results/refine-results/faceting/how-to/declaring-attributes-for-faceting) |
+| `distinct: true` plus `attributeForDistinct: 'slug'` | Package search default | This groups a post's multiple fragment records and returns the most relevant fragment. Algolia ignores `distinct` without `attributeForDistinct`; the setting is search behavior rather than an indexing prerequisite. [Algolia: distinct](https://www.algolia.com/doc/api-reference/api-parameters/distinct) |
+| `customRanking` on heading and position | Package search default | It orders otherwise tied fragments using fields produced by the fragmenter. Algolia applies custom ranking as part of relevance; it is not required to save or delete records. [Algolia: custom ranking](https://www.algolia.com/doc/guides/managing-results/must-do/custom-ranking/how-to/configure-custom-ranking) |
+| `searchableAttributes` | User-overridable relevance default | The selected fields and their order define what is searched and influence ranking. Algolia supports configuring them through either the dashboard or API. [Algolia: searchable attributes](https://www.algolia.com/doc/guides/managing-results/must-do/searchable-attributes) |
+
+The package should document the full default profile, but it should guarantee only the prerequisite that its own mutation algorithm needs. Under the current slug-filter deletion design, operators using the Netlify unpublish webhook must provision `filterOnly(slug)` once. The CLI's default profile does this. If a custom patch changes `attributesForFaceting`, it must retain `filterOnly(slug)`; validation should reject an incompatible explicit value rather than silently rewriting user-owned settings.
+
+The distinct and ranking defaults should remain defaults, not invariants silently forced on every publish. A consumer may intentionally display multiple fragments per post or choose different relevance, and neither choice prevents indexing.
+
+## Implementation consequence
+
+The compatible fix is small and independent of the HTML extractor implementation:
+
+1. Change `post-published` to call `initIndex()` instead of `setSettingsForIndex()` before `save()`.
+2. Update its acceptance tests to require only the records batch for publish events and to prove no settings endpoint is called.
+3. Remove `settings` and `editSettings` from the Netlify key requirements and documentation; the publish/unpublish runtime still needs record-add and slug-filter deletion permissions. Algolia documents `addObject`, `deleteIndex`, `settings`, and `editSettings` as separate ACL capabilities. [Algolia: API keys](https://www.algolia.com/doc/guides/security/api-keys)
+4. Document that index setup is a prerequisite to webhooks, with `filterOnly(slug)` required while unpublishing uses `deleteBy`. Keep the CLI as the supported initial-setup path.
+5. Add focused CLI/indexer coverage for a minimal custom settings patch if stronger end-to-end evidence than the existing indexer test is wanted. This is coverage hardening, not the original defect.
+
+Do not make the fragmenter consume `searchableAttributes`. The fragmenter determines record shape; Algolia settings determine which existing record fields are searchable. Additional Ghost-field projection belongs with the separate projection/excerpt decision, not this fix.
+
+## Disposition of the original report
+
+Close [Searchable attributes in the config file are not added to algolia](https://github.com/TryGhost/algolia/issues/23) with a comment that:
+
+- the CLI/config path now sends custom `indexSettings` and has contract coverage;
+- the fragmenter's field projection is deliberately separate from Algolia search settings;
+- the remaining webhook reset is superseded by the explicit configuration-ownership decision above and should be implemented under a narrowly named task.
+
+Retitling the old issue would preserve a misleading history and mix two contracts. A fresh implementation task should be named for the actual behavior, for example **Stop publish webhooks from rewriting Algolia index settings**.
+
+## Verification performed
+
+- Inspected the current checkout and `origin/main`; both retain the same CLI-versus-Netlify settings ownership behavior.
+- Traced the original configuration file, CLI, indexer, fragmenter, publish handler, unpublish handler, and their public-seam tests.
+- Traced the introduction of `setSettingsForIndex({updateSettings: false})` in commit `7679651`; neither the historical nor current Netlify publish handler uses it.
+- Checked the relevant Algolia settings, searchable-attribute, distinct, custom-ranking, filtering, deletion, and ACL documentation cited above.

--- a/docs/research/html-parser-primitive.md
+++ b/docs/research/html-parser-primitive.md
@@ -1,0 +1,41 @@
+# HTML parser primitive
+
+## Decision
+
+Use `parse5@7.3.0` as the parser and serializer primitive for the compatibility-first public extractor.
+
+Implement the extraction state machine as clean-room Ghost code against parse5's tree-adapter data. Do not port the abandoned JavaScript package or the Ruby extractor.
+
+## Why parse5 7.3.0
+
+- It implements WHATWG HTML parsing and serialization, which is the right baseline for malformed HTML, entities, tables, and browser-like tree construction.
+- It is MIT-licensed and has one runtime dependency, `entities`.
+- Version 7.3.0 publishes conditional `import` and `require` exports. That lets a synchronous public extractor serve both ESM consumers and the fragmenter's existing CommonJS `require` seam without bundling the parser or converting the fragmenter to ESM.
+- It is itself implemented in TypeScript and publishes bundled declaration files for both its ESM and CommonJS builds. The planned monorepo TypeScript migration therefore does not require parse5 8: source-language migration and an ESM-only package contract are separate decisions. The extractor can be authored in TypeScript now while preserving the compatibility-first dual-module boundary.
+- It exposes parsing and serialization primitives without a browser simulation, network stack, or general selector engine that this fixed traversal contract does not need.
+
+Parse5 8 is the current major but is ESM-only. Using it now would require an ESM-only extractor, asynchronous loading from CommonJS, converting the fragmenter, or bundling a second CJS artifact. Each option expands the compatibility-first slice. Pin 7.3.0 and add a Renovate compatibility rule preventing an automatic parse5 8 upgrade until the public package's module contract is intentionally revisited.
+
+## Rejected alternatives
+
+- **jsdom**: closest to the abandoned implementation's DOM surface, but simulates substantially more browser behaviour and carries a much larger dependency graph than the extraction contract needs.
+- **Cheerio**: provides convenient selectors and supports Node 24, but arbitrary selectors are not part of the chosen narrow package boundary and its dependency surface is broader.
+- **htmlparser2 or LinkeDOM**: optimize for different performance or DOM trade-offs; strict browser-compatible HTML tree construction and serialization are more important for differential parity.
+- **Copying either extractor**: retains unused API baggage and introduces avoidable provenance and attribution work. The npm tarball declares ISC but does not contain a license file; the upstream Ruby implementation is MIT.
+
+## Validation required during implementation
+
+The parser choice is conditional on the exact differential suite passing against the frozen legacy contract. Pay particular attention to `outerHTML` serialization, entity spelling, document fragments, malformed tables, foreign content, void elements, and nested selected nodes. Any normalized difference must return to the map as a compatibility decision rather than being accepted incidentally.
+
+The Netlify package must continue to expose the parser to its file tracer through an explicit direct dependency or an equivalently verified packaged seam.
+
+## Sources
+
+- [parse5 7.3.0 package metadata](https://github.com/inikulin/parse5/blob/v7.3.0/packages/parse5/package.json)
+- [published parse5 7.3.0 package tarball](https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz)
+- [parse5 7.3.0 TypeScript entry point](https://github.com/inikulin/parse5/blob/v7.3.0/packages/parse5/lib/index.ts)
+- [parse5 7.3.0 TypeScript build configuration](https://github.com/inikulin/parse5/blob/v7.3.0/packages/parse5/tsconfig.json)
+- [parse5 8 package metadata](https://github.com/inikulin/parse5/blob/v8.0.0/packages/parse5/package.json)
+- [parse5 project](https://github.com/inikulin/parse5)
+- [`algolia-html-extractor` implementation](https://github.com/stonecircle/html-extractor/blob/master/lib/algoliaHtmlExtractor.js)
+- [Algolia Ruby extractor license](https://github.com/algolia/html-extractor/blob/develop/LICENSE.txt)

--- a/docs/research/legacy-extraction-compatibility-contract.md
+++ b/docs/research/legacy-extraction-compatibility-contract.md
@@ -1,0 +1,58 @@
+# Legacy extraction compatibility contract
+
+## Decision
+
+The compatibility-first `@tryghost/algolia-html-extractor` release must preserve the final Algolia records produced by the current fragmenter exactly. Compatibility is judged at the public record seam, not by reproducing unused internals of `algolia-html-extractor@0.0.1`.
+
+## Observable extraction behaviour
+
+- Parse an HTML string with browser-compatible HTML5 tree construction.
+- Visit `h1` through `h6` and selected `p`, `pre`, `td`, and `li` elements in document order, including nested selected elements.
+- Track six heading levels. A heading replaces its own level and clears every deeper level; skipped levels remain absent from the emitted heading path.
+- Extract heading and selected-node content with DOM `textContent` semantics.
+- Ignore a selected node only when its text content has length zero. Whitespace-only content remains observable.
+- Serialize selected nodes as trimmed `outerHTML`.
+- Prefer a heading's `name`, then its `id`, then the first descendant carrying `name` or `id` as its anchor.
+- Preserve the previous anchor when a later heading has no anchor. This surprising carry-forward behaviour is part of parity.
+- Number only emitted, non-empty selected nodes from zero.
+- Rank content outside headings at 100, under `h1` at 90, decreasing by 10 per level through `h6` at 40.
+
+## Observable fragmenter behaviour
+
+- Group extraction fragments by strict anchor equality within one Ghost content item, preserving the first occurrence's position, headings, ranking, and order.
+- Merge all unanchored fragments into the first `null`-anchor group; merge repeated anchors even when they occur in separate parts of the document.
+- Append ordinary selected-node HTML without a separator and append its text with one leading space.
+- When merging a `pre` node, discard its markup and append its text with one leading space to both accumulated HTML and text.
+- Remove the extractor's DOM node and text fields before producing records.
+- Ignore the extractor's generated ID. Assign final IDs as `<Ghost content id>_<group index>`.
+- Add `#<anchor>` to the Ghost content URL when the group has an anchor.
+- Spread the grouped extraction fields over the post projection to create the final Algolia record.
+
+## Non-contract internals
+
+The replacement does not need to preserve the abandoned package's constructor shape, MD5 generator, generic CSS-selector API, tag-exclusion option, exposed DOM node, or `object.omit` usage unless the separate public-API decision deliberately adopts one of them.
+
+## Parity evidence required
+
+Differential tests must compare complete final records and cover:
+
+- every heading level, skipped levels, and hierarchy resets;
+- direct `name`, direct `id`, descendant anchors, missing anchors, and repeated anchors;
+- headingless content and multiple unanchored elements;
+- `p`, `pre`, `td`, and `li` order, including nested selected elements;
+- empty and whitespace-only nodes;
+- inline markup, entities, Unicode, void elements, and exact serialization;
+- malformed HTML and table tree construction;
+- merge order, deep-link URLs, ranking, and final IDs;
+- representative Ghost 6 rendered HTML from the reviewed fixture corpus.
+
+Real Ghost output contains cards, captions, image alternative text, table headers, blockquotes, and other structures outside the legacy selector. Ignoring those structures remains intentional in the compatibility release; richer extraction belongs to its own decision.
+
+## Sources
+
+- [`algolia-html-extractor` implementation](https://github.com/stonecircle/html-extractor/blob/master/lib/algoliaHtmlExtractor.js)
+- [Original Algolia Ruby extractor](https://github.com/algolia/html-extractor/blob/develop/lib/algolia_html_extractor.rb)
+- [Ghost Content API posts](https://docs.ghost.org/content-api/posts)
+- `packages/algolia-fragmenter/lib/transformer.js`
+- `packages/algolia-fragmenter/test/fragmenter.test.js`
+- `packages/algolia/test/cli-ghost-v6.acceptance.test.js`


### PR DESCRIPTION
## Summary

- define the shared Ghost-to-Algolia domain language
- freeze the legacy extraction compatibility contract and parser choice
- document Algolia record-size constraints and the remaining Netlify settings defect

## Why

These source-backed decisions make the [HTML-to-Algolia Wayfinder map](https://github.com/TryGhost/algolia/issues/186) durable in the repository and give later implementation slices explicit compatibility and ownership boundaries. This PR changes documentation only; it does not alter runtime behaviour.

## Validation

- `pnpm test` on Node 24.18.0 — 103 tests passed; typecheck, oxlint, and oxfmt passed through the test lifecycle
- `pnpm typecheck` on Node 24.18.0
- `git diff --check`

Refs #186