### PR TITLE
Document Ghost content projection contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,7 @@ An Algolia record attribute whose name and meaning are owned by the package to p
 _Avoid_: Custom field, pass-through field
 
 **Optional projection field**:
-An allowlisted public Ghost content field that projection configuration may include, omit, or expose under a validated alias. Enabled optional fields are repeated in every Algolia record derived from that Ghost content.
+An allowlisted public Ghost source field or package-owned compatibility projection that projection configuration may include, omit, or expose under a validated alias. Enabled optional fields are repeated in every Algolia record derived from that Ghost content.
 _Avoid_: Custom field, arbitrary field
 
 **Extraction fragment**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,9 +8,17 @@ Ghost Algolia turns published Ghost content into structured records for an Algol
 A published post or page returned by the Ghost Content API, including its metadata and rendered HTML.
 _Avoid_: Page, document, article when the resource type is not important
 
-**Post projection**:
-The selected Ghost content fields that are carried into every Algolia record derived from that content.
-_Avoid_: Base record, Algolia post
+**Ghost content projection**:
+The protected record fields and configured optional projection fields that are carried into every Algolia record derived from Ghost content.
+_Avoid_: Post projection, base record, Algolia post
+
+**Protected record field**:
+An Algolia record attribute whose name and meaning are owned by the package to preserve identity, navigation, fragment structure, ranking, or deletion behaviour. Projection configuration cannot omit or override it.
+_Avoid_: Custom field, pass-through field
+
+**Optional projection field**:
+An allowlisted public Ghost content field that projection configuration may include, omit, or expose under a validated alias. Enabled optional fields are repeated in every Algolia record derived from that Ghost content.
+_Avoid_: Custom field, arbitrary field
 
 **Extraction fragment**:
 An ordered unit of rendered HTML associated with its current heading path, anchor, and position.

--- a/docs/research/ghost-content-projection-contract.md
+++ b/docs/research/ghost-content-projection-contract.md
@@ -144,11 +144,13 @@ Reject a policy before processing content when it contains:
 - an unknown or repeated source;
 - a repeated output name;
 - an alias colliding with a protected field;
+- an alias equal to the package-owned `customRanking` container, whether used
+  by a projection field or ranking field;
 - an alias impersonating any canonical allowlist name, even when that field is
   omitted;
 - `heading` or `position` inside `customRanking`;
 - an Algolia-reserved name, including `_highlightResult`, `_snippetResult`,
-  `_rankingInfo`, `_distinctSeqID`, `_tags`, or `_geoloc`;
+  `_rankingInfo`, `_distinctSeqID`, `distinctSeqId`, `_tags`, or `_geoloc`;
 - a dot, leading underscore, wildcard, expression, arbitrary source path, or
   executable mapper.
 
@@ -181,17 +183,22 @@ For an enabled field:
 - a present value with the wrong documented type fails validation;
 - correctly typed values are copied without coercion or sanitization.
 
-Consumers render `excerpt` as escaped text. Fragment `html` remains HTML and
-is not redefined as sanitized display text.
+Consumers escape `excerpt` and every other projected text value before
+rendering it as text. The projection layer does not sanitize fragment `html`
+or Algolia highlight output; consumers sanitize both before rendering them as
+HTML.
 
 Ghost content that produces no extraction fragments emits one projection-only
-fallback record:
+fallback record. This example shows its fixed fields; policy-dependent optional
+fields and custom-ranking siblings are omitted:
 
 ```json
 {
   "objectID": "<content id>_0",
+  "slug": "<content slug>",
   "url": "<base content URL>",
   "html": "",
+  "title": "<content title>",
   "headings": [],
   "anchor": null,
   "customRanking": {
@@ -201,9 +208,9 @@ fallback record:
 }
 ```
 
-The fallback also contains the protected Ghost fields, every enabled optional
-field, and configured custom-ranking siblings. It uses the existing
-headingless rank and does not copy plaintext into `html`.
+The normative fallback contains every enabled optional field and configured
+custom-ranking sibling in addition to the fixed fields shown above. It uses the
+existing headingless rank and does not copy plaintext into `html`.
 
 ## Size, ordering, and failures
 

--- a/docs/research/ghost-content-projection-contract.md
+++ b/docs/research/ghost-content-projection-contract.md
@@ -1,0 +1,282 @@
+# Ghost content projection contract
+
+Status: approved through human review on 2026-08-14.
+
+This contract resolves the record-projection decisions behind
+[HTML tags in search results](https://github.com/TryGhost/algolia/issues/148)
+and
+[Extend algoliaPost with additional Ghost post fields](https://github.com/TryGhost/algolia/issues/43).
+The primary-source constraints are recorded separately in
+[Ghost field projection: primary-source constraints](ghost-field-projection-primary-source-constraints.md).
+
+## Module interface
+
+`@tryghost/algolia-fragmenter` exposes one new deep synchronous interface that
+turns Ghost content into complete final Algolia records:
+
+```ts
+export type OptionalProjectionSource =
+    | 'image'
+    | 'tags'
+    | 'authors'
+    | 'excerpt'
+    | 'custom_excerpt'
+    | 'feature_image_alt'
+    | 'feature_image_caption'
+    | 'canonical_url'
+    | 'featured'
+    | 'visibility'
+    | 'created_at'
+    | 'updated_at'
+    | 'published_at'
+    | 'reading_time';
+
+export type ProjectionField =
+    | OptionalProjectionSource
+    | Readonly<{
+          source: OptionalProjectionSource;
+          as: string;
+      }>;
+
+export type RankingSource = 'featured' | 'reading_time';
+
+export type RankingField = Readonly<{
+    source: RankingSource;
+    as: string;
+}>;
+
+export type ContentProjection = Readonly<{
+    fields: readonly ProjectionField[];
+    customRanking?: readonly RankingField[];
+}>;
+
+export type CreateAlgoliaRecordsOptions = Readonly<{
+    ignoreSlugs?: readonly string[];
+    contentProjection?: ContentProjection;
+}>;
+
+export function createAlgoliaRecords(
+    ghostContent: readonly GhostContent[],
+    options?: CreateAlgoliaRecordsOptions
+): readonly AlgoliaRecord[];
+```
+
+The interface owns post/page projection, HTML extraction, legacy-compatible
+grouping, fallback-record creation, deep links, identifiers, ranking metadata,
+deterministic size handling, and validation. Callers do not coordinate those
+stages.
+
+The existing `transformToAlgoliaObject(posts, ignoreSlugs?)` and
+`fragmentTransformer` exports remain deprecated compatibility wrappers. They
+retain their current behaviour and do not receive the new projection policy.
+CLI and Netlify adapters migrate to `createAlgoliaRecords` when the new
+behaviour is released.
+
+All new source and tests are strict TypeScript. ESM, CommonJS, declarations,
+and source maps are generated package artifacts rather than hand-authored
+variants.
+
+## Protected record fields
+
+These final-record fields are package-owned and cannot be omitted, aliased, or
+overridden:
+
+- `objectID`
+- `slug`
+- `url`
+- `title`
+- `html`
+- `headings`
+- `anchor`
+- `customRanking.heading`
+- `customRanking.position`
+
+`objectID`, deep-link `url`, fragment `html`, `headings`, `anchor`, and the two
+protected ranking values are derived by the fragmenter. The required Ghost
+input fields are `id`, `slug`, `url`, `title`, and `html`.
+
+## Default and configured projection
+
+When `contentProjection` is absent, the optional field set is:
+
+- `image`
+- `tags`
+- `authors`
+- `excerpt`
+
+`excerpt` is the Ghost-computed presentation excerpt: the custom excerpt when
+present, otherwise Ghost's generated plaintext excerpt. It is projected in
+addition to fragment `html`, not instead of it. `custom_excerpt` is not a
+default because it can duplicate `excerpt`.
+
+When `contentProjection` is present, `fields` is required and is the complete
+desired optional field set. An empty array is valid. There are no additive or
+subtractive patch lists and no schema-version property; package semver governs
+the public configuration contract.
+
+The initial optional allowlist is exactly:
+
+- compatibility/display fields: `image`, `tags`, `authors`, `excerpt`;
+- excerpt and image metadata: `custom_excerpt`, `feature_image_alt`,
+  `feature_image_caption`;
+- navigation and state: `canonical_url`, `featured`, `visibility`;
+- time and reading metadata: `created_at`, `updated_at`, `published_at`,
+  `reading_time`.
+
+`image` retains the compatibility mapping from Ghost's `feature_image`.
+`tags` and `authors` retain arrays of `{name, slug}`. Making either relation
+optional means including, omitting, or aliasing that complete compatibility
+shape; it does not expose arbitrary relation fields.
+
+Raw source formats, plaintext, code injection, frontmatter, SEO/social
+duplicates, internal identifiers, richer relation objects, and arbitrary
+future Ghost properties are not selectable. Expanding the allowlist later is
+compatible; arbitrary pass-through is not.
+
+## Aliases and collisions
+
+An optional projection field may use an alias matching
+`^[A-Za-z][A-Za-z0-9_]*$`. Aliases are single record-attribute names, not object
+paths.
+
+Reject a policy before processing content when it contains:
+
+- an unknown or repeated source;
+- a repeated output name;
+- an alias colliding with a protected field;
+- an alias impersonating any canonical allowlist name, even when that field is
+  omitted;
+- `heading` or `position` inside `customRanking`;
+- an Algolia-reserved name, including `_highlightResult`, `_snippetResult`,
+  `_rankingInfo`, `_distinctSeqID`, `_tags`, or `_geoloc`;
+- a dot, leading underscore, wildcard, expression, arbitrary source path, or
+  executable mapper.
+
+Aliases change only the output key. They do not change or coerce the value's
+type.
+
+## Additional custom-ranking values
+
+The fragmenter always emits package-owned `customRanking.heading` and
+`customRanking.position`. A policy may add sibling values sourced from the
+allowlisted numeric or boolean fields `featured` and `reading_time`.
+
+Each configured sibling requires a validated output alias. Missing values
+become `null`. The fragmenter does not initially convert timestamps, evaluate
+expressions, or accept ranking callbacks. Index owners remain free to choose
+which emitted ranking fields Algolia uses.
+
+## Projection and fallback behaviour
+
+Enabled optional fields are repeated in every Algolia record derived from the
+same Ghost content. This keeps every candidate fragment returned by Algolia's
+distinct handling self-contained. Every repeated key and value counts toward
+that record's size.
+
+For an enabled field:
+
+- a missing scalar becomes `null`;
+- missing `tags` or `authors` becomes `[]`;
+- meaningful `false`, `0`, and empty-string values are preserved;
+- a present value with the wrong documented type fails validation;
+- correctly typed values are copied without coercion or sanitization.
+
+Consumers render `excerpt` as escaped text. Fragment `html` remains HTML and
+is not redefined as sanitized display text.
+
+Ghost content that produces no extraction fragments emits one projection-only
+fallback record:
+
+```json
+{
+  "objectID": "<content id>_0",
+  "url": "<base content URL>",
+  "html": "",
+  "headings": [],
+  "anchor": null,
+  "customRanking": {
+    "heading": 100,
+    "position": 0
+  }
+}
+```
+
+The fallback also contains the protected Ghost fields, every enabled optional
+field, and configured custom-ranking siblings. It uses the existing
+headingless rank and does not copy plaintext into `html`.
+
+## Size, ordering, and failures
+
+Output order is Ghost-content input order, then first-seen legacy anchor-group
+order, then continuation order. The fragmenter applies the already-approved
+deterministic size policy after legacy grouping:
+
+- every complete compact record is at most 9,999 UTF-8 bytes;
+- whole extraction fragments are greedily packed without truncation;
+- the first record keeps `<content id>_<group index>`;
+- continuations add `_<continuation index>`;
+- configured metadata is never silently dropped to make a record fit.
+
+`createAlgoliaRecords` validates the whole batch and returns no records when
+any deterministic policy, content, or size problem exists. One public
+`FragmenterError` exposes a discriminated code:
+
+- `INVALID_POLICY`
+- `INVALID_GHOST_CONTENT`
+- `RECORD_TOO_LARGE`
+
+Its structured details contain all deterministic issues in input order. Size
+issues include content identity, anchor and source position when available,
+measured bytes, the 9,999-byte ceiling, and excess. Unexpected implementation
+defects remain native errors.
+
+Ignored slugs are identified and removed before full protected-field and
+record validation, while still requiring a valid slug to make the exclusion
+decision.
+
+## Shared adapters
+
+The same JSON-serializable `contentProjection` shape is used by every caller:
+
+- direct package callers pass `options.contentProjection`;
+- CLI configuration uses a top-level `contentProjection` property;
+- canonical Netlify handlers parse `ALGOLIA_CONTENT_PROJECTION` as JSON.
+
+Invalid configuration is reported before Ghost fetching or Algolia writes.
+The CLI continues to request public scalar fields without a `fields`
+parameter. It adds `include=tags` and/or `include=authors` only when those
+optional relations are enabled. Netlify applies the same projection to the
+webhook's current Ghost content object.
+
+The contract applies identically to Ghost posts and pages. Endpoint selection
+and page enumeration belong to the separate page-indexing decision, not to
+projection.
+
+## Algolia settings ownership
+
+Projection controls record data only. It never implicitly makes a field
+searchable, retrievable, facetable, or rankable and never mutates index
+settings during a webhook request.
+
+The package's current default `searchableAttributes` remain unchanged;
+`excerpt` is display-only under those defaults. Sites that customize
+projection own the corresponding explicit Algolia settings. Naming a missing
+attribute in settings is tolerated by Algolia but does not synthesize it.
+
+## Compatibility and source-request disposition
+
+The extractor-replacement slice still preserves existing final records
+exactly. Default `excerpt`, configurable projection, fallback records, the new
+deep fragmenter interface, and deterministic size behaviour are separately
+released follow-on changes. The implementation-and-release-sequence decision
+owns their package and migration order.
+
+The two source requests receive a link to this approved contract but remain
+open until the implementation ships. Delivery—not planning—closes them.
+
+Rejected alternatives include replacing fragment HTML with excerpt; defaulting
+`custom_excerpt`; arbitrary pass-through or executable mappers; allowing
+callers to overwrite protected fragment ranking; patch-style include/exclude
+configuration; automatically rewriting Algolia settings; returning partial
+batches; silently truncating or dropping fields; and closing the source
+requests before delivery.

--- a/docs/research/ghost-field-projection-primary-source-constraints.md
+++ b/docs/research/ghost-field-projection-primary-source-constraints.md
@@ -1,0 +1,208 @@
+# Ghost field projection: primary-source constraints
+
+Status: researched against current official Ghost and Algolia documentation, and
+Ghost `origin/main` at
+[`c92ae410594d164c95254d7aaba498c4e963c332`](https://github.com/TryGhost/Ghost/commit/c92ae410594d164c95254d7aaba498c4e963c332),
+on 2026-08-14.
+
+This note records facts that constrain **Decide the Ghost field projection and
+excerpt contract**. It does not choose the projected fields, configuration
+shape, aliases, or index settings.
+
+## Ghost Content API surface
+
+The Content API is a read-only API for published content. Ghost describes its
+keys as safe for browser use because they provide access to public data, while
+warning that private sites should control where they share keys. That makes the
+Content API response the appropriate public-data boundary; it does not make
+every returned value useful or safe to copy into a frontend search index.
+([Content API overview](https://docs.ghost.org/content-api/))
+
+All endpoints accept `fields` to limit scalar fields in the response and
+`include` to add relations. For posts and pages, `include=authors,tags` adds the
+relation arrays and their `primary_author` / `primary_tag` values. Ghost warns
+that `fields` "does not play well" with `include`, so relation projection cannot
+be assumed to behave like scalar field selection. Posts return only `html` by
+default; `formats=html,plaintext` requests the additional plaintext form.
+([Content API parameters](https://docs.ghost.org/content-api/parameters))
+
+The documented post response and current output source together expose these
+field families:
+
+- identity and navigation: `id`, `uuid`, `title`, `slug`, `url`,
+  `canonical_url`, and `comment_id`;
+- searchable or display content: `html`, `custom_excerpt`, computed `excerpt`,
+  `feature_image`, `feature_image_alt`, and `feature_image_caption`;
+- state and time: `featured`, `visibility`, `created_at`, `updated_at`,
+  `published_at`, computed `reading_time`, and computed `access`;
+- metadata: `custom_template`, `meta_*`, `og_*`, `twitter_*`, `email_subject`,
+  `frontmatter`, and the two `codeinjection_*` values; and
+- optional relation objects from `include=authors,tags`.
+
+The official page contract says pages are structured identically to posts;
+only the resource key and default browse order differ. The response example is
+the public contract to program against; Ghost does not publish a separate,
+exhaustive `fields` allowlist.
+([posts response](https://docs.ghost.org/content-api/posts),
+[pages response](https://docs.ghost.org/content-api/pages),
+[metadata projection source](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js#L123-L136))
+
+Current Ghost source corroborates the boundary and exposes two stability
+constraints:
+
+- Both public controllers accept `fields` and `formats`. Their public includes
+  are explicitly allowlisted rather than arbitrary relations.
+  ([posts controller](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/api/endpoints/posts-public.js#L11-L73),
+  [pages controller](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/api/endpoints/pages-public.js#L8-L49))
+- `mobiledoc` and `lexical` are deliberately removed from Content API format
+  and column selection. They are source formats, not selectable public content
+  formats. `html` and `plaintext` are the public content forms.
+  ([post input serializer](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js#L20-L60),
+  [page input serializer](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js#L25-L50))
+
+### Excerpt semantics
+
+`custom_excerpt` and `excerpt` are distinct public fields:
+
+- `custom_excerpt` is the author-supplied value. Ghost's current schema
+  validates it to at most 300 characters.
+- `plaintext` is derived from rendered HTML when the post is saved.
+- `excerpt` is computed at serialization time: a present custom excerpt wins;
+  otherwise Ghost takes the first 500 JavaScript string characters of
+  `plaintext`. Requesting `excerpt` causes Ghost to fetch `plaintext` and
+  `custom_excerpt` internally, but it returns `custom_excerpt` only when that
+  field was separately requested.
+
+Therefore `excerpt` is a fallback presentation value, not a second stored copy
+of `custom_excerpt`, and projecting both can intentionally duplicate the same
+text for posts that have a custom excerpt.
+([schema](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/data/schema/schema.js#L62-L99),
+[plaintext generation](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/models/post.js#L745-L759),
+[excerpt serializer](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/extra-attrs.js#L10-L64),
+[excerpt query dependencies](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/models/base/plugins/crud.js#L10-L18))
+
+The public serializer also applies membership gating before returning content.
+For a caller without access it truncates HTML at the legacy paywall marker or
+empties `html`, `plaintext`, and computed `excerpt`; gated blocks are removed
+and derived text is recalculated. A projection must consequently use the values
+actually returned by the Content API, not assume that a published post's stored
+HTML or generated excerpt is always present in full.
+([content gating serializer](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/post-gating.js#L72-L123))
+
+### Public does not mean suitable for indexing
+
+Ghost strips author email, status, notification, and other internal fields from
+Content API author objects, and rejects Content API query paths containing
+`email` or `password`. These are useful minimum boundaries, not a complete
+search-index policy: public post responses still include values such as code
+injection, frontmatter, canonical URLs, and social metadata that may add noise,
+HTML, URLs, or unnecessary bytes when copied into Algolia.
+([public output cleaning](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/clean.js#L27-L78),
+[restricted query fields](https://github.com/TryGhost/Ghost/blob/c92ae410594d164c95254d7aaba498c4e963c332/ghost/core/core/server/api/endpoints/utils/api-filter-utils.ts#L1-L18))
+
+## Algolia record and settings constraints
+
+Algolia records are schemaless JSON. Algolia recommends including only values
+needed for searching, displaying, filtering, or relevance. Records should be
+self-contained: duplicating parent metadata into flattened child records is
+normal, but every duplicated key and value is stored and counted in each
+record.
+([prepare records](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data),
+[prepare an index](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/prepare-data-in-depth))
+
+### Attribute names and collisions
+
+`objectID` uniquely identifies a record and is always returned, even if omitted
+from `attributesToRetrieve` or listed in `unretrievableAttributes`. It must not
+contain sensitive information. Algolia also reserves `_highlightResult`,
+`_snippetResult`, `_rankingInfo`, and `_distinctSeqID` for search responses;
+records should not use those names. `_tags` and `_geoloc` are record-side
+reserved attributes with imposed schemas. A configurable projection needs to
+prevent user-selected or future source names from colliding with these names or
+with package-owned record attributes.
+([Algolia record attributes](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/what-is-in-a-record))
+
+### Stored, searchable, returned, and displayed are separate roles
+
+- If `searchableAttributes` is unset or empty, Algolia searches every
+  string-based attribute. Once configured, it limits search to the named
+  attributes and their order affects the Attribute ranking criterion. Names are
+  case-sensitive and naming a parent makes all nested children searchable.
+  ([`searchableAttributes`](https://www.algolia.com/doc/api-reference/api-parameters/searchableAttributes))
+- `attributesToRetrieve` controls search responses and defaults to all
+  attributes; `unretrievableAttributes` prevents normal search keys from
+  retrieving selected values, but is ignored for an Admin API key. Neither
+  setting removes the values from stored records.
+  ([`attributesToRetrieve`](https://www.algolia.com/doc/api-reference/api-parameters/attributesToRetrieve),
+  [`unretrievableAttributes`](https://www.algolia.com/doc/api-reference/api-parameters/unretrievableAttributes/))
+- Filtering or faceting requires the attribute in `attributesForFaceting`.
+  `filterOnly(attribute)` enables filtering without facet values and reduces
+  index overhead. Array filters match when any element matches.
+  ([`attributesForFaceting`](https://www.algolia.com/doc/api-reference/api-parameters/attributesForFaceting),
+  [`filters`](https://www.algolia.com/doc/api-reference/api-parameters/filters))
+- `customRanking` is a tie-breaker over named record attributes. The order of
+  settings matters; missing or `null` values sort after populated records. The
+  data-preparation guide requires custom-ranking values to be numeric or
+  boolean.
+  ([`customRanking`](https://www.algolia.com/doc/api-reference/api-parameters/customRanking),
+  [record preparation](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data))
+
+Configuring any of these roles does not synthesize a missing record attribute.
+Conversely, projecting an attribute without explicitly setting
+`searchableAttributes` can make an otherwise display-only string searchable by
+default.
+
+### HTML, highlighting, and snippets
+
+Algolia accepts and returns submitted HTML unchanged and does not sanitize it.
+It ignores HTML tags while matching. By default it highlights all searchable
+attributes and adds match tags to `_highlightResult`; its UI guidance requires
+sanitizing highlighted HTML because unsanitized content can enable XSS.
+Algolia's snippeting path strips HTML tags. Consequently, raw HTML, plaintext,
+and a precomputed excerpt are not interchangeable display/search contracts.
+([data cleaning](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/data-sanitization),
+[`attributesToHighlight`](https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight),
+[highlighting and snippeting](https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js))
+
+### Multiple fragment records
+
+Algolia recommends splitting long pages at logical boundaries. `distinct`
+groups records that share `attributeForDistinct`; `distinct=true` returns only
+the most relevant record from each group. Fields needed to render that winning
+fragment must therefore exist on every candidate record. When facet values are
+shared by all records in a distinct group, `afterDistinct` is the documented
+way to calculate facet counts after deduplication.
+([index long pages](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/indexing-long-documents/),
+[`distinct`](https://www.algolia.com/doc/api-reference/api-parameters/distinct),
+[`attributesForFaceting`](https://www.algolia.com/doc/api-reference/api-parameters/attributesForFaceting))
+
+### Full-record size accounting
+
+Current online plans limit each free-plan record to 10 KB; paid plans allow a
+100 KB individual record but impose a 10 KB average. Algolia measures the final
+JSON after removing syntactically unnecessary whitespace. Attribute names,
+values, arrays, nested objects, generated IDs, and all metadata repeated across
+fragments therefore consume the budget. Retrieval and search settings provide
+no size exemption.
+([record-size limits and accounting](https://support.algolia.com/hc/en-us/articles/4406981897617-Is-there-a-size-limit-for-my-index-records),
+[reduce record size](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/reducing-object-size),
+[repository size research](algolia-record-size-constraints.md))
+
+## Questions these facts leave to the decision
+
+The sources do not decide:
+
+- the stable allowlist and any explicit denylist for configurable Ghost fields;
+- whether fields keep Ghost names, are mapped to package-owned names, or may be
+  aliased;
+- whether `excerpt`, `custom_excerpt`, neither, or both are projected, and which
+  are searchable versus display-only;
+- the scalar representation of authors and tags;
+- whether all projected metadata is repeated on every fragment or only a
+  documented subset; or
+- which index settings the package owns as defaults, prerequisites, or user
+  policy.
+
+Those choices must be made together: projection changes affect default search
+scope, response exposure, highlighting safety, distinct-result rendering, and
+the byte budget of every generated fragment record.

--- a/docs/research/ghost-field-projection-primary-source-constraints.md
+++ b/docs/research/ghost-field-projection-primary-source-constraints.md
@@ -115,11 +115,12 @@ record.
 `objectID` uniquely identifies a record and is always returned, even if omitted
 from `attributesToRetrieve` or listed in `unretrievableAttributes`. It must not
 contain sensitive information. Algolia also reserves `_highlightResult`,
-`_snippetResult`, `_rankingInfo`, and `_distinctSeqID` for search responses;
-records should not use those names. `_tags` and `_geoloc` are record-side
-reserved attributes with imposed schemas. A configurable projection needs to
-prevent user-selected or future source names from colliding with these names or
-with package-owned record attributes.
+`_snippetResult`, `_rankingInfo`, and `_distinctSeqID` for search responses.
+`distinctSeqId` is a record-side reserved name. Records should not use any of
+those names. `_tags` and `_geoloc` are also record-side reserved attributes with
+imposed schemas. A configurable projection needs to prevent user-selected or
+future source names from colliding with these names or with package-owned
+record attributes.
 ([Algolia record attributes](https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/what-is-in-a-record))
 
 ### Stored, searchable, returned, and displayed are separate roles


### PR DESCRIPTION
## What changed

- document the approved `createAlgoliaRecords` interface and Ghost content projection contract
- record the primary-source Ghost and Algolia constraints behind the decision
- update the domain glossary with protected and optional projection terminology

## Why

The Wayfinder decision needed a durable, implementation-ready contract that keeps Ghost field projection separate from HTML extraction and Algolia settings. This records the agreed defaults, allowlist, aliases, validation, fallback records, size behavior, adapter configuration, and compatibility boundary before implementation is sequenced.

## Validation

- `pnpm test` on Node 24.19.0 and pnpm 11.19.0
- 103 tests passed
- TypeScript typecheck passed
- oxlint and oxfmt passed
- signed commit verified locally

## Tracking

- [Plan a maintained HTML-to-Algolia extraction pipeline](https://github.com/TryGhost/algolia/issues/186)
- [Decide the Ghost field projection and excerpt contract](https://github.com/TryGhost/algolia/issues/196)