### PR TITLE
Tolerate empty published content in the live smoke

### DIFF
--- a/docs/research/live-ghost-content-api-smoke-contract.md
+++ b/docs/research/live-ghost-content-api-smoke-contract.md
@@ -171,8 +171,12 @@ The smoke program has four layers of assertions:
 1. **Target and transport:** exact origin and API version, non-empty key,
    successful non-redirected JSON responses.
 2. **Content API schema:** resource arrays, pagination object, valid progress to
-   `next === null`, at least one Ghost content item in the combined read, and a
-   string `html` value for every item.
+   `next === null`, a string or `null` `html` value for every item, and at least
+   one observed `html` string in the combined read. A `null` value is counted
+   per resource, contributes no signature, and never reaches the normalizer or
+   the extractor; every other non-string value remains schema drift. Because a
+   read whose items all carry `null` exercises neither the normalizer nor the
+   extractor, it fails as an empty census exactly like a read with no items.
 3. **Normalizer privacy and determinism:** parsing succeeds; two passes over the
    same in-memory HTML yield the same normalized signature; and emitted
    signatures contain only the structural allowlist above.
@@ -180,6 +184,20 @@ The smoke program has four layers of assertions:
    A new identifier fails the live workflow. Missing identifiers and changed
    occurrence counts are reported but do not fail, because mutable editorial
    content can remove or duplicate structures without changing Ghost's renderer.
+
+Amended on 2026-08-20. Layer 2 originally required a string `html` value for
+every item. Two manual dispatches failed `schema-drift` on that assertion alone
+([run 32368632595](https://github.com/TryGhost/algolia/actions/runs/32368632595),
+[run 32372419243](https://github.com/TryGhost/algolia/actions/runs/32372419243)).
+A maintainer-led aggregate classification of the first posts page found
+`{"null": 8, "string": 92}` over healthy pagination, and all eight `null`-`html`
+items were `public`: empty-bodied published posts, not restricted content. Ghost
+returns `null` `html` for an empty published post, and equally for members-only
+and paid posts, so the pinned assertion contradicted live Content API behaviour
+and made every dispatch fail regardless of key or timing. Empty published posts
+are mutable editorial content, which this contract requires to be reported
+rather than treated as fatal.
+([amendment](https://github.com/TryGhost/algolia/issues/239))
 
 Once `@tryghost/algolia-html-extractor` exists, also invoke its public `extract`
 seam for every live HTML value and assert only interface invariants: no throw,
@@ -233,6 +251,8 @@ On every run, write one compact, deterministic report to the GitHub job summary:
   `structural-drift`, or `extractor-failure`;
 - UTC observation time, explicit safe origin, and API version;
 - pages and items read per resource;
+- items without an `html` value per resource, as a count only, so the summary is
+  itself the complete census of empty-bodied published content;
 - total distinct normalized signatures;
 - signature identifier and aggregate count for each observed signature;
 - added, missing, and count-changed identifiers relative to baseline.
@@ -316,6 +336,7 @@ revealing automation.
 
 - [Plan a maintained HTML-to-Algolia extraction pipeline](https://github.com/TryGhost/algolia/issues/186)
 - [Define the live Ghost Content API smoke contract](https://github.com/TryGhost/algolia/issues/191)
+- [Live smoke schema contract fails on published posts with null html](https://github.com/TryGhost/algolia/issues/239)
 - [Provision read-only `main.ghost.is` Content API access](https://github.com/TryGhost/algolia/issues/190#issuecomment-5289038849)
 - [`CONTEXT.md`](../../CONTEXT.md)
 - [`ghost-html-evidence-corpus.md`](ghost-html-evidence-corpus.md)

--- a/docs/research/live-ghost-content-api-smoke-contract.md
+++ b/docs/research/live-ghost-content-api-smoke-contract.md
@@ -252,7 +252,8 @@ On every run, write one compact, deterministic report to the GitHub job summary:
 - UTC observation time, explicit safe origin, and API version;
 - pages and items read per resource;
 - items without an `html` value per resource, as a count only, so the summary is
-  itself the complete census of empty-bodied published content;
+  itself the complete census of items with `html: null`, whether empty-bodied,
+  members-only, or paid;
 - total distinct normalized signatures;
 - signature identifier and aggregate count for each observed signature;
 - added, missing, and count-changed identifiers relative to baseline.

--- a/packages/algolia-html-extractor/smoke/live-ghost-content-smoke.mts
+++ b/packages/algolia-html-extractor/smoke/live-ghost-content-smoke.mts
@@ -40,6 +40,7 @@ export type SmokeTransport = (request: SmokeTransportRequest) => Promise<SmokeTr
 export type ResourceTotals = Readonly<{
     pages: number;
     items: number;
+    itemsWithoutHtml: number;
 }>;
 
 export type SmokeReport = Readonly<{
@@ -88,7 +89,7 @@ type Node = DefaultTreeAdapterTypes.Node;
 type ParentNode = DefaultTreeAdapterTypes.ParentNode;
 
 type SmokeState = {
-    totals: Record<GhostContentType, {pages: number; items: number}>;
+    totals: Record<GhostContentType, {pages: number; items: number; itemsWithoutHtml: number}>;
     signatureCounts: Map<SignatureId, number>;
 };
 
@@ -135,8 +136,8 @@ export class SmokeError extends Error {
 
 const createState = (): SmokeState => ({
     totals: {
-        posts: {pages: 0, items: 0},
-        pages: {pages: 0, items: 0}
+        posts: {pages: 0, items: 0, itemsWithoutHtml: 0},
+        pages: {pages: 0, items: 0, itemsWithoutHtml: 0}
     },
     signatureCounts: new Map()
 });
@@ -195,6 +196,10 @@ const formatIdentifiers = (identifiers: readonly SignatureId[]): string => {
     return identifiers.length === 0 ? 'none' : identifiers.join(', ');
 };
 
+const formatResourceTotals = (contentType: GhostContentType, totals: ResourceTotals): string => {
+    return `| ${contentType} | ${totals.pages} | ${totals.items} | ${totals.itemsWithoutHtml} |`;
+};
+
 export function formatSmokeSummary(report: SmokeReport): string {
     const signatureLines = report.signatures.map(({id, count}) => `| ${id} | ${count} |`);
     const signatureTable = signatureLines.length === 0 ? '| none | 0 |' : signatureLines.join('\n');
@@ -207,10 +212,10 @@ export function formatSmokeSummary(report: SmokeReport): string {
         `Target: ${report.target}`,
         `API version: ${report.apiVersion}`,
         '',
-        '| Resource | Pages | Items |',
-        '| --- | ---: | ---: |',
-        `| posts | ${report.totals.posts.pages} | ${report.totals.posts.items} |`,
-        `| pages | ${report.totals.pages.pages} | ${report.totals.pages.items} |`,
+        '| Resource | Pages | Items | Without html |',
+        '| --- | ---: | ---: | ---: |',
+        formatResourceTotals('posts', report.totals.posts),
+        formatResourceTotals('pages', report.totals.pages),
         '',
         `Distinct signatures: ${report.signatures.length}`,
         '',
@@ -578,6 +583,30 @@ const observeHtml = (renderedHtml: string, state: SmokeState): void => {
     state.signatureCounts.set(signature, (state.signatureCounts.get(signature) ?? 0) + 1);
 };
 
+const observeItem = (item: unknown, contentType: GhostContentType, state: SmokeState): void => {
+    if (!isObject(item)) {
+        throw new SmokeAbort('schema-drift', 'invalid-schema');
+    }
+
+    const totals = state.totals[contentType];
+
+    // Ghost returns a null html value for an item with an empty rendered body. Such an item is
+    // counted so resource totals still reconcile with the declared pagination total, but it
+    // carries no structure to census and reaches neither the normalizer nor the extractor.
+    if (item.html === null) {
+        totals.itemsWithoutHtml += 1;
+        totals.items += 1;
+        return;
+    }
+
+    if (typeof item.html !== 'string') {
+        throw new SmokeAbort('schema-drift', 'invalid-schema');
+    }
+
+    observeHtml(item.html, state);
+    totals.items += 1;
+};
+
 const readContentType = async (
     options: LiveGhostContentSmokeOptions,
     contentType: GhostContentType,
@@ -608,11 +637,7 @@ const readContentType = async (
         }
 
         for (const item of items) {
-            if (!isObject(item) || typeof item.html !== 'string') {
-                throw new SmokeAbort('schema-drift', 'invalid-schema');
-            }
-            observeHtml(item.html, state);
-            state.totals[contentType].items += 1;
+            observeItem(item, contentType, state);
         }
         state.totals[contentType].pages += 1;
 
@@ -665,7 +690,11 @@ export async function runLiveGhostContentSmoke(
         baseline = validateBaseline(options.baseline);
         await readContentType(options, 'posts', state);
         await readContentType(options, 'pages', state);
-        if (state.totals.posts.items + state.totals.pages.items === 0) {
+        // A combined read that observed no html value at all, whether from no items or only
+        // items without html, exercised neither the normalizer nor the extractor. It is no
+        // evidence of the live contract and must never become a baseline.
+        const hasStructuralEvidence = state.signatureCounts.size > 0;
+        if (!hasStructuralEvidence) {
             throw new SmokeAbort('schema-drift', 'empty-census');
         }
     } catch (error) {

--- a/packages/algolia-html-extractor/test/live-ghost-content-smoke.cli.test.ts
+++ b/packages/algolia-html-extractor/test/live-ghost-content-smoke.cli.test.ts
@@ -138,8 +138,8 @@ describe('live Ghost content smoke CLI', () => {
 
         const summary = await readFile(summaryPath, 'utf8');
         expect(summary).toContain('Result: ok');
-        expect(summary).toContain('| posts | 1 | 1 |');
-        expect(summary).toContain('| pages | 1 | 0 |');
+        expect(summary).toContain('| posts | 1 | 1 | 0 |');
+        expect(summary).toContain('| pages | 1 | 0 | 0 |');
         expect(summary).not.toMatch(/Private fixture prose|test-content-api-key/i);
     });
 

--- a/packages/algolia-html-extractor/test/live-ghost-content-smoke.test.ts
+++ b/packages/algolia-html-extractor/test/live-ghost-content-smoke.test.ts
@@ -25,23 +25,23 @@ const createOptions = (
     ...overrides
 });
 
-const createSuccessfulTransport = (
-    postHtml: readonly string[],
-    pageHtml: readonly string[]
+const createSinglePageTransport = (
+    postItems: readonly unknown[],
+    pageItems: readonly unknown[]
 ): SmokeTransport => {
     return vi.fn<SmokeTransport>(async request => {
-        const htmlValues = request.contentType === 'posts' ? postHtml : pageHtml;
+        const items = request.contentType === 'posts' ? postItems : pageItems;
         return {
             status: 200,
             redirected: false,
             body: {
-                [request.contentType]: htmlValues.map(html => ({html})),
+                [request.contentType]: items,
                 meta: {
                     pagination: {
                         page: 1,
                         limit: 100,
                         pages: 1,
-                        total: htmlValues.length,
+                        total: items.length,
                         next: null,
                         prev: null
                     }
@@ -51,10 +51,39 @@ const createSuccessfulTransport = (
     });
 };
 
+const createSuccessfulTransport = (
+    postHtml: readonly (string | null)[],
+    pageHtml: readonly (string | null)[]
+): SmokeTransport => {
+    return createSinglePageTransport(
+        postHtml.map(html => ({html})),
+        pageHtml.map(html => ({html}))
+    );
+};
+
 const signatureFor = (canonicalStructure: unknown): `sha256:${string}` => {
     const serializedStructure = JSON.stringify(canonicalStructure);
     return `sha256:${createHash('sha256').update(serializedStructure, 'utf8').digest('hex')}`;
 };
+
+const PARAGRAPH_STRUCTURE = {
+    version: 1,
+    nodes: [
+        {tag: 'html', parent: null, kgClasses: [], attributes: []},
+        {tag: 'head', parent: 0, kgClasses: [], attributes: []},
+        {tag: 'body', parent: 0, kgClasses: [], attributes: []},
+        {tag: 'p', parent: 2, kgClasses: [], attributes: []}
+    ],
+    headings: [],
+    selectedCounts: {p: 1, pre: 0, td: 0, li: 0},
+    semanticGaps: {
+        caption: false,
+        tableHeader: false,
+        blockquote: false,
+        figure: false,
+        cardWrapper: false
+    }
+} as const;
 
 describe('runLiveGhostContentSmoke', () => {
     it.each([
@@ -163,8 +192,8 @@ describe('runLiveGhostContentSmoke', () => {
             target: 'https://main.ghost.is',
             apiVersion: 'v6.0',
             totals: {
-                posts: {pages: 2, items: 2},
-                pages: {pages: 1, items: 1}
+                posts: {pages: 2, items: 2, itemsWithoutHtml: 0},
+                pages: {pages: 1, items: 1, itemsWithoutHtml: 0}
             },
             drift: {added: [], missing: [], countChanged: []}
         });
@@ -195,6 +224,137 @@ describe('runLiveGhostContentSmoke', () => {
         expect(summaries[0]).not.toMatch(
             /private|prose|quotation|heading|\.invalid|post-id|test-content-api-key/i
         );
+    });
+
+    it('counts items without html, keeps them out of the census, and never extracts them', async () => {
+        const summaries: string[] = [];
+
+        const report = await runLiveGhostContentSmoke(
+            createOptions(
+                createSuccessfulTransport(
+                    ['<p>Private prose one</p>', null, '<p>Private prose two</p>'],
+                    [null]
+                ),
+                {
+                    summarySink: summary => {
+                        summaries.push(summary);
+                    }
+                }
+            )
+        );
+
+        expect(report.category).toBe('ok');
+        expect(report.totals).toEqual({
+            posts: {pages: 1, items: 3, itemsWithoutHtml: 1},
+            pages: {pages: 1, items: 1, itemsWithoutHtml: 1}
+        });
+        expect(report.signatures).toEqual([{id: signatureFor(PARAGRAPH_STRUCTURE), count: 2}]);
+        expect(summaries[0]).not.toMatch(/private|prose/i);
+    });
+
+    it('reconciles declared totals when items without html span pages and resources', async () => {
+        const responses: SmokeTransportResponse[] = [
+            {
+                status: 200,
+                redirected: false,
+                body: {
+                    posts: [{html: null}, {html: '<p>Private prose one</p>'}],
+                    meta: {
+                        pagination: {page: 1, limit: 100, pages: 2, total: 3, next: 2, prev: null}
+                    }
+                }
+            },
+            {
+                status: 200,
+                redirected: false,
+                body: {
+                    posts: [{html: null}],
+                    meta: {
+                        pagination: {page: 2, limit: 100, pages: 2, total: 3, next: null, prev: 1}
+                    }
+                }
+            },
+            {
+                status: 200,
+                redirected: false,
+                body: {
+                    pages: [{html: null}, {html: '<p>Private prose two</p>'}],
+                    meta: {
+                        pagination: {
+                            page: 1,
+                            limit: 100,
+                            pages: 1,
+                            total: 2,
+                            next: null,
+                            prev: null
+                        }
+                    }
+                }
+            }
+        ];
+        const transport = vi.fn<SmokeTransport>(async () => {
+            const response = responses.shift();
+            if (response === undefined) {
+                throw new Error('unexpected request');
+            }
+            return response;
+        });
+
+        const report = await runLiveGhostContentSmoke(createOptions(transport));
+
+        expect(report.category).toBe('ok');
+        expect(report.totals).toEqual({
+            posts: {pages: 2, items: 3, itemsWithoutHtml: 2},
+            pages: {pages: 1, items: 2, itemsWithoutHtml: 1}
+        });
+        expect(report.signatures).toEqual([{id: signatureFor(PARAGRAPH_STRUCTURE), count: 2}]);
+    });
+
+    it('renders the aggregate of items without html as a summary column', async () => {
+        const summaries: string[] = [];
+
+        await runLiveGhostContentSmoke(
+            createOptions(createSuccessfulTransport(['<p>Private prose</p>', null], [null]), {
+                summarySink: summary => {
+                    summaries.push(summary);
+                }
+            })
+        );
+
+        expect(summaries[0]).toContain(
+            [
+                '| Resource | Pages | Items | Without html |',
+                '| --- | ---: | ---: | ---: |',
+                '| posts | 1 | 2 | 1 |',
+                '| pages | 1 | 1 | 1 |'
+            ].join('\n')
+        );
+    });
+
+    it.each([
+        ['a numeric html value', {html: 12}],
+        ['an array html value', {html: []}],
+        ['an object html value', {html: {private: 'private item value'}}],
+        ['a missing html property', {private: 'private item value'}],
+        ['an explicitly undefined html value', {html: undefined}],
+        ['a non-object item', 'private item value'],
+        ['a null item', null]
+    ])('keeps %s fatal', async (_name, item) => {
+        const summaries: string[] = [];
+
+        const execution = runLiveGhostContentSmoke(
+            createOptions(createSinglePageTransport([item], []), {
+                summarySink: summary => {
+                    summaries.push(summary);
+                }
+            })
+        );
+
+        await expect(execution).rejects.toMatchObject({
+            category: 'schema-drift',
+            code: 'invalid-schema'
+        });
+        expect(summaries[0]).not.toMatch(/private/i);
     });
 
     it('rejects an invalid baseline before transport without echoing its entries', async () => {
@@ -690,6 +850,55 @@ describe('runLiveGhostContentSmoke', () => {
         });
     });
 
+    it('rejects a combined census whose items all lack html while reporting their counts', async () => {
+        const summaries: string[] = [];
+
+        const execution = runLiveGhostContentSmoke(
+            createOptions(createSuccessfulTransport([null, null], [null]), {
+                summarySink: summary => {
+                    summaries.push(summary);
+                }
+            })
+        );
+
+        await expect(execution).rejects.toMatchObject({
+            category: 'schema-drift',
+            code: 'empty-census'
+        });
+        expect(summaries).toHaveLength(1);
+        expect(summaries[0]).toContain('| posts | 1 | 2 | 2 |');
+        expect(summaries[0]).toContain('| pages | 1 | 1 | 1 |');
+        expect(summaries[0]).toContain('Distinct signatures: 0');
+    });
+
+    it('keeps baseline comparison unaffected by items without html', async () => {
+        const postHtml = ['<p>First private value</p>'];
+        const pageHtml = ['<blockquote>Second private value</blockquote>'];
+        const bootstrap = await runLiveGhostContentSmoke(
+            createOptions(createSuccessfulTransport(postHtml, pageHtml))
+        );
+        const reviewedBaseline = Object.fromEntries(
+            bootstrap.signatures.map(({id, count}) => [id, count])
+        ) as Record<`sha256:${string}`, number>;
+
+        const withoutHtml = await runLiveGhostContentSmoke(
+            createOptions(
+                createSuccessfulTransport([null, ...postHtml, null], [...pageHtml, null]),
+                {
+                    baseline: reviewedBaseline
+                }
+            )
+        );
+
+        expect(withoutHtml.category).toBe('ok');
+        expect(withoutHtml.drift).toEqual({added: [], missing: [], countChanged: []});
+        expect(withoutHtml.signatures).toEqual(bootstrap.signatures);
+        expect(withoutHtml.totals).toEqual({
+            posts: {pages: 1, items: 3, itemsWithoutHtml: 2},
+            pages: {pages: 1, items: 2, itemsWithoutHtml: 1}
+        });
+    });
+
     it('accepts the real extractor interface invariants across every compatibility source tag', async () => {
         const renderedHtml = [
             '<h2><a id="private-anchor">Private heading</a></h2>',
@@ -705,8 +914,8 @@ describe('runLiveGhostContentSmoke', () => {
 
         expect(report.category).toBe('ok');
         expect(report.totals).toEqual({
-            posts: {pages: 1, items: 1},
-            pages: {pages: 1, items: 0}
+            posts: {pages: 1, items: 1, itemsWithoutHtml: 0},
+            pages: {pages: 1, items: 0, itemsWithoutHtml: 0}
         });
         expect(report.signatures).toHaveLength(1);
     });


### PR DESCRIPTION
Amends the live smoke's Content API schema layer per #239 so dispatches stop failing on published posts whose rendered body is empty.

## Why

Both bootstrap dispatches ([32368632595](https://github.com/TryGhost/algolia/actions/runs/32368632595), [32372419243](https://github.com/TryGhost/algolia/actions/runs/32372419243)) failed `schema-drift` because the pinned assertion required a string `html` for every item, while the live origin has 8 published public posts with `html: null` — Ghost's Content API behavior for empty-bodied posts (and equally for members-only/paid posts on sites that have them). Empty published posts are mutable editorial content, which the smoke contract requires to be reported, not fatal.

## What changed

- A `null` `html` value is tolerated: the item is counted in the resource's `items` total (pagination totals still reconcile against the API's declared total), increments a new per-resource `itemsWithoutHtml` count, contributes no structural signature, and never reaches the normalizer or the extractor. Any other non-string `html` — and a non-object item — remains fatal `schema-drift`.
- The job summary gains a `Without html` column in the per-resource table, so the summary itself is the complete census of empty-bodied content across all pages of both resources. Counts only; no item is ever identified.
- The `empty-census` check now keys on structural evidence (`signatureCounts.size > 0`) instead of item counts: a read whose items are all null-`html` exercises neither the normalizer nor the extractor and must never become a baseline, exactly like a zero-item read.
- `docs/research/live-ghost-content-api-smoke-contract.md` records the amendment with a dated note citing both failing runs and the aggregate classification evidence.

## Verification

- `pnpm --filter @tryghost/algolia-html-extractor test` — 61 tests across 6 files pass (12 new public-seam cases: mixed null/string pages, per-resource counts, all-null → `empty-census`, non-string and non-object items still fatal, summary rendering, drift unaffected), plus package typecheck, oxlint, and oxfmt.
- Root `pnpm test`, `pnpm typecheck`, `pnpm lint` — clean (one unrelated failure comes from a transient `.claude/worktrees/` checkout of a separate session that the root vitest glob picks up; the repository's own suite passes fully).
- No changed or new line is uncovered; the smoke module's branch coverage rose slightly.
- Privacy assertions extended: mixed and failure summaries are asserted to contain counts and fixed labels only.

## Sequencing

Refs #239 — close it only after this merges and a fresh manual dispatch on `main` returns `ok`. That green dispatch is also the entry point for resuming #219 (second-maintainer review, baseline, schedule). Rollback is reverting this change; no package release is involved.
