### PR TITLE
Fixed Netlify build output landing outside the package in git worktrees

### DIFF
--- a/patches/@netlify__config.patch
+++ b/patches/@netlify__config.patch
@@ -1,0 +1,29 @@
+diff --git a/lib/options/repository_root.js b/lib/options/repository_root.js
+index 3802695e3061b92f4a1e8a71ed3e21509ecff7e1..56e40f9e189407b0c7490a80d57c0f63c328d3fd 100644
+--- a/lib/options/repository_root.js
++++ b/lib/options/repository_root.js
+@@ -1,16 +1,20 @@
+-import { dirname } from 'path';
++import { existsSync } from 'fs';
++import { join } from 'path';
+ import { findUp } from 'find-up';
+ // Find out repository root among (in priority order):
+ //  - `repositoryRoot` option
+-//  - find a `.git` directory up from `cwd`
++//  - find a `.git` entry up from `cwd` (a directory in a standard checkout, a file in a git worktree)
+ //  - `cwd` (fallback)
+ export const getRepositoryRoot = async function ({ repositoryRoot, cwd }) {
+     if (repositoryRoot !== undefined) {
+         return repositoryRoot;
+     }
+-    const repositoryRootA = await findUp('.git', { cwd, type: 'directory' });
++    const repositoryRootA = await findUp((directory) => (existsSync(join(directory, '.git')) ? directory : undefined), {
++        cwd,
++        type: 'directory',
++    });
+     if (repositoryRootA === undefined) {
+         return cwd;
+     }
+-    return dirname(repositoryRootA);
++    return repositoryRootA;
+ };

--- a/patches/netlify-cli.patch
+++ b/patches/netlify-cli.patch
@@ -1,0 +1,20 @@
+diff --git a/dist/commands/base-command.js b/dist/commands/base-command.js
+index cb8b30f23b270933350dcaec6cb9a336ebf72390..cd0151aba71726498c28e71f32d8cd652af24b73 100644
+--- a/dist/commands/base-command.js
++++ b/dist/commands/base-command.js
+@@ -114,9 +114,13 @@ async function selectWorkspace(project, filter) {
+     return selected.path;
+ }
+ async function getRepositoryRoot(cwd) {
+-    const res = await findUp('.git', { cwd, type: 'directory' });
++    // `.git` is a directory in a standard checkout but a file in a git worktree
++    const res = await findUp((directory) => (existsSync(join(directory, '.git')) ? directory : undefined), {
++        cwd,
++        type: 'directory',
++    });
+     if (res) {
+-        return join(res, '..');
++        return res;
+     }
+ }
+ export function storeToken(globalConfig, { userId, name, email, accessToken }) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@netlify/config': 3f7fb3e9f184413d5b76da489221d2e0a03164a2c01fb5aa5406d829335eef3e
+  netlify-cli: 2f63d36e26d64621837c892279c0017056c9a84f0e694194a062b2e59e97824e
+
 importers:
 
   .:
@@ -106,7 +110,7 @@ importers:
         version: 0.28.2
       netlify-cli:
         specifier: 27.1.1
-        version: 27.1.1(@types/node@24.13.3)(picomatch@4.0.5)(supports-color@10.2.2)
+        version: 27.1.1(patch_hash=2f63d36e26d64621837c892279c0017056c9a84f0e694194a062b2e59e97824e)(@types/node@24.13.3)(picomatch@4.0.5)(supports-color@10.2.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -7842,7 +7846,7 @@ snapshots:
       '@bugsnag/js': 8.10.0
       '@netlify/blobs': 10.7.13(supports-color@10.2.2)
       '@netlify/cache-utils': 7.1.1
-      '@netlify/config': 25.2.2
+      '@netlify/config': 25.2.2(patch_hash=3f7fb3e9f184413d5b76da489221d2e0a03164a2c01fb5aa5406d829335eef3e)
       '@netlify/edge-bundler': 16.0.3
       '@netlify/functions-utils': 7.1.4(supports-color@10.2.2)
       '@netlify/git-utils': 7.1.0
@@ -7914,7 +7918,7 @@ snapshots:
     dependencies:
       '@netlify/runtime-utils': 2.3.0
 
-  '@netlify/config@25.2.2':
+  '@netlify/config@25.2.2(patch_hash=3f7fb3e9f184413d5b76da489221d2e0a03164a2c01fb5aa5406d829335eef3e)':
     dependencies:
       '@netlify/api': 15.1.1
       '@netlify/headers-parser': 10.1.1
@@ -7981,7 +7985,7 @@ snapshots:
     dependencies:
       '@netlify/ai': 0.4.4
       '@netlify/blobs': 10.7.13(supports-color@10.2.2)
-      '@netlify/config': 25.2.2
+      '@netlify/config': 25.2.2(patch_hash=3f7fb3e9f184413d5b76da489221d2e0a03164a2c01fb5aa5406d829335eef3e)
       '@netlify/database-dev': 0.10.1
       '@netlify/dev-utils': 5.0.0
       '@netlify/edge-functions-dev': 1.0.24
@@ -11625,7 +11629,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  netlify-cli@27.1.1(@types/node@24.13.3)(picomatch@4.0.5)(supports-color@10.2.2):
+  netlify-cli@27.1.1(patch_hash=2f63d36e26d64621837c892279c0017056c9a84f0e694194a062b2e59e97824e)(@types/node@24.13.3)(picomatch@4.0.5)(supports-color@10.2.2):
     dependencies:
       '@fastify/static': 10.1.3
       '@netlify/ai': 0.4.4
@@ -11633,7 +11637,7 @@ snapshots:
       '@netlify/blobs': 10.7.13(supports-color@10.2.2)
       '@netlify/build': 36.3.5(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(picomatch@4.0.5)
       '@netlify/build-info': 11.3.0
-      '@netlify/config': 25.2.2
+      '@netlify/config': 25.2.2(patch_hash=3f7fb3e9f184413d5b76da489221d2e0a03164a2c01fb5aa5406d829335eef3e)
       '@netlify/dev': 4.18.13(supports-color@10.2.2)
       '@netlify/dev-utils': 4.4.7
       '@netlify/edge-bundler': 16.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,3 +13,7 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - '@tryghost/errors'
   - '@tryghost/pretty-cli'
+
+patchedDependencies:
+  '@netlify/config': patches/@netlify__config.patch
+  netlify-cli: patches/netlify-cli.patch


### PR DESCRIPTION
## Problem

`pnpm --filter @tryghost/algolia-netlify build` misbehaves when run from a git worktree (e.g. under `.claude/worktrees/`): the function zips land at the worktree root `.netlify/functions/` instead of `packages/algolia-netlify/.netlify/functions/`, so `function-tracing.acceptance.test.mjs` always fails there with ENOENT. In a normal checkout and CI everything works.

## Root cause

Both **netlify-cli** (`getRepositoryRoot` in `dist/commands/base-command.js`) and **@netlify/config** (`lib/options/repository_root.js`) locate the repository root with `findUp('.git', { type: 'directory' })`. In a worktree `.git` is a *file*, so the lookup walks past it and lands on the main checkout's `.git` directory. With the root pointing at the main checkout:

1. the worktree's relative path isn't one of that root's workspace packages, so workspace detection returns `null`;
2. `--filter @tryghost/algolia-netlify` is silently ignored;
3. the root `netlify.toml` is used and zips land at the worktree root.

Both layers need the fix. The CLI always passes a `defaultConfig` to `@netlify/build`, and `@netlify/config` discards the CLI's correctly-resolved `cachedConfig` whenever `defaultConfig` is set — its re-resolution then runs the same buggy `.git` lookup. Patching only the CLI made the re-resolution build against the **main checkout**, which is worse.

The bug is still present on netlify/cli `main` as of 2026-08-20, so a version bump can't fix it.

## Fix

Two `pnpm` patches, each the same one-line idea: accept `.git` as a file or a directory (`existsSync(join(directory, '.git'))` as a `find-up` matcher).

They are registered under **name-only keys** in `patchedDependencies`, so Renovate bumps keep applying them, and `pnpm install` fails loudly if a future version changes that code — at which point upstream may have fixed the worktree bug and the patch can be dropped.

## Verification

- **Worktree:** zips now land in `packages/algolia-netlify/.netlify/functions/`, nothing at the worktree root; full root suite passes (20 files / 157 tests) plus lint and typecheck under Node 24.
- **Normal checkout** (fresh testbed with a real `.git` directory, `pnpm install --frozen-lockfile`): resolution is byte-for-byte identical to before the patch (root `netlify.toml` as config file, repo root as build dir, zips in the package directory) and the full suite passes.
- Function URLs, the build-publishes-only-`public/` contract, and all package sources are untouched — the diff is only the two patch files, `pnpm-workspace.yaml`, and `pnpm-lock.yaml`.