### PR TITLE
Fixed deploys silently dropping the HTML extractor from function bundles

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,8 @@
 [build]
-  command = "pnpm typecheck"
+  # Deploys run only this command; package "prebuild" scripts never run on Netlify. The
+  # extractor's gitignored dist/ must exist before functions bundling, or the bundler silently
+  # drops the package from the function archives and the functions crash at runtime.
+  command = "pnpm --filter @tryghost/algolia-html-extractor build && pnpm typecheck"
   functions = "packages/algolia-netlify/functions"
   publish = "packages/algolia-netlify/public"
 

--- a/packages/algolia-netlify/netlify.toml
+++ b/packages/algolia-netlify/netlify.toml
@@ -1,6 +1,9 @@
 [build]
   base = "."
-  command = "pnpm typecheck"
+  # Deploys run only this command; package "prebuild" scripts never run on Netlify. The
+  # extractor's gitignored dist/ must exist before functions bundling, or the bundler silently
+  # drops the package from the function archives and the functions crash at runtime.
+  command = "pnpm --filter @tryghost/algolia-html-extractor build && pnpm typecheck"
   functions = "functions"
   publish = "public"
 

--- a/packages/algolia-netlify/test/function-tracing.acceptance.test.mjs
+++ b/packages/algolia-netlify/test/function-tracing.acceptance.test.mjs
@@ -64,6 +64,7 @@ describe('Netlify function dependency tracing', () => {
 
                 expect(archiveIndex).toContain('packages/algolia-html-extractor/package.json');
                 expect(archiveIndex).toContain('packages/algolia-html-extractor/dist/index.mjs');
+                expect(archiveIndex).toContain('/node_modules/parse5/dist/index.js');
             }
         } finally {
             await execFileAsync('pnpm', ['--filter', '@tryghost/algolia-html-extractor', 'build'], {

--- a/packages/algolia-netlify/test/function-tracing.acceptance.test.mjs
+++ b/packages/algolia-netlify/test/function-tracing.acceptance.test.mjs
@@ -13,6 +13,9 @@ const extractorDistDirectory = path.resolve(
     workspaceDirectory,
     'packages/algolia-html-extractor/dist'
 );
+// The workspace root has no netlify binary; resolve the pinned CLI from this package so the
+// test does not depend on a globally installed netlify-cli.
+const netlifyBinary = path.join(packageDirectory, 'node_modules/.bin/netlify');
 
 describe('Netlify function dependency tracing', () => {
     it('packages the compatibility extractor through the ESM fragmenter', async () => {
@@ -43,13 +46,15 @@ describe('Netlify function dependency tracing', () => {
 
         try {
             await execFileAsync(
-                'pnpm',
-                ['exec', 'netlify', 'build', '--offline', '--filter', '@tryghost/algolia-netlify'],
+                netlifyBinary,
+                ['build', '--offline', '--filter', '@tryghost/algolia-netlify'],
                 {
                     cwd: workspaceDirectory,
                     env: {...process.env, NODE_ENV: 'production'}
                 }
-            );
+            ).catch(error => {
+                throw new Error(`${error.message}\n${error.stdout ?? ''}\n${error.stderr ?? ''}`);
+            });
 
             for (const functionName of ['post-published', 'post-unpublished']) {
                 const archive = await readFile(

--- a/packages/algolia-netlify/test/function-tracing.acceptance.test.mjs
+++ b/packages/algolia-netlify/test/function-tracing.acceptance.test.mjs
@@ -1,5 +1,5 @@
 import {execFile} from 'node:child_process';
-import {readFile} from 'node:fs/promises';
+import {readFile, rm} from 'node:fs/promises';
 import path from 'node:path';
 import {promisify} from 'node:util';
 import {fileURLToPath} from 'node:url';
@@ -9,6 +9,10 @@ import {describe, expect, it} from 'vitest';
 const execFileAsync = promisify(execFile);
 const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const workspaceDirectory = path.resolve(packageDirectory, '../..');
+const extractorDistDirectory = path.resolve(
+    workspaceDirectory,
+    'packages/algolia-html-extractor/dist'
+);
 
 describe('Netlify function dependency tracing', () => {
     it('packages the compatibility extractor through the ESM fragmenter', async () => {
@@ -31,4 +35,35 @@ describe('Netlify function dependency tracing', () => {
             expect(archiveIndex).not.toContain(workspaceDirectory);
         }
     }, 30000);
+
+    it('packages the extractor on a deploy without prebuilt workspace output', async () => {
+        // Production deploys run only the netlify.toml build command on a fresh clone, where the
+        // gitignored extractor dist/ does not exist; package "prebuild" scripts never run there.
+        await rm(extractorDistDirectory, {recursive: true, force: true});
+
+        try {
+            await execFileAsync(
+                'pnpm',
+                ['exec', 'netlify', 'build', '--offline', '--filter', '@tryghost/algolia-netlify'],
+                {
+                    cwd: workspaceDirectory,
+                    env: {...process.env, NODE_ENV: 'production'}
+                }
+            );
+
+            for (const functionName of ['post-published', 'post-unpublished']) {
+                const archive = await readFile(
+                    path.join(packageDirectory, `.netlify/functions/${functionName}.zip`)
+                );
+                const archiveIndex = archive.toString('latin1');
+
+                expect(archiveIndex).toContain('packages/algolia-html-extractor/package.json');
+                expect(archiveIndex).toContain('packages/algolia-html-extractor/dist/index.mjs');
+            }
+        } finally {
+            await execFileAsync('pnpm', ['--filter', '@tryghost/algolia-html-extractor', 'build'], {
+                cwd: workspaceDirectory
+            });
+        }
+    }, 60000);
 });


### PR DESCRIPTION
## Problem

Production `post-published`/`post-unpublished` functions crash with:

```
Cannot find package '@tryghost/algolia-html-extractor' imported from /var/task/packages/algolia-fragmenter/lib/index.mjs
```

Every consumer site building off `main` has shipped this broken bundle since bfdf972 ("Changed fragmenter to ESM and the maintained HTML extractor").

## Root cause

- The fragmenter's committed `lib/index.mjs` imports `@tryghost/algolia-html-extractor`, whose entry point is `./dist/index.mjs`.
- That `dist/` is gitignored, and the Netlify build command (`pnpm typecheck`) never built it — typecheck passes regardless, because `tsconfig.base.json` `paths` maps the package name to its *source*.
- With the entry file missing at bundle time, the functions bundler silently drops the package: the archive contains a dangling `packages/algolia-fragmenter/node_modules/@tryghost/algolia-html-extractor` symlink and no real package, so Node throws `ERR_MODULE_NOT_FOUND` at runtime.

Locally this is masked: `pnpm build` in `algolia-netlify` runs a `prebuild` hook that builds the extractor first. Netlify never runs package scripts — only the toml command — and the existing tracing test exercised the masked local seam, so it stayed green while production broke.

## Fix

Build the extractor in the Netlify build command, in the **root** `netlify.toml` (the config production actually resolves — verified via `netlify build`'s "Config file" output). The package-level toml gets the identical command so `netlify dev` and any base-configured site behave the same.

## Verification

- New acceptance test reproduces the deploy contract: removes the extractor's `dist/`, runs `netlify build --offline` directly (no package scripts), and asserts the function archives contain the real extractor package. Red before the fix, green after.
- Confirmed the fixed bundle contains `packages/algolia-html-extractor/package.json`, `dist/index.mjs`, and the full `parse5` dependency.
- Full suite under Node 24: 652 passed; the only 2 failures are the known netlify-cli git-worktree quirk in stale local `.claude/worktrees` checkouts (#241), unrelated to this change and absent in CI.

## After merge

Merging auto-deploys to all consumer sites. Posts published/unpublished while deploys were broken were silently dropped from indexes — affected sites should reindex via the CLI.