### PR TITLE
Skipped the Netlify tracing tests inside git worktree checkouts

### DIFF
--- a/packages/algolia-netlify/test/function-tracing.acceptance.test.mjs
+++ b/packages/algolia-netlify/test/function-tracing.acceptance.test.mjs
@@ -1,4 +1,5 @@
 import {execFile} from 'node:child_process';
+import {statSync} from 'node:fs';
 import {readFile, rm} from 'node:fs/promises';
 import path from 'node:path';
 import {promisify} from 'node:util';
@@ -16,8 +17,13 @@ const extractorDistDirectory = path.resolve(
 // The workspace root has no netlify binary; resolve the pinned CLI from this package so the
 // test does not depend on a globally installed netlify-cli.
 const netlifyBinary = path.join(packageDirectory, 'node_modules/.bin/netlify');
+// netlify-cli resolves the repository root by searching for a `.git` directory, and in a git
+// worktree `.git` is a file, so build output lands outside the checkout. Netlify builds are
+// deliberately only verified in standard checkouts; CI always runs in one.
+const isWorktreeCheckout =
+    statSync(path.join(workspaceDirectory, '.git'), {throwIfNoEntry: false})?.isFile() ?? false;
 
-describe('Netlify function dependency tracing', () => {
+describe.skipIf(isWorktreeCheckout)('Netlify function dependency tracing', () => {
     it('packages the compatibility extractor through the ESM fragmenter', async () => {
         await execFileAsync('pnpm', ['--filter', '@tryghost/algolia-netlify', 'build'], {
             cwd: workspaceDirectory


### PR DESCRIPTION
## Why

netlify-cli resolves the repository root by searching for a `.git` **directory**. In a git worktree `.git` is a file, so the search walks past the checkout and build output lands outside the package — both function-tracing tests then fail for reasons unrelated to the code under test.

[#241](https://github.com/TryGhost/algolia/pull/241) tried to fix this by patching netlify-cli and `@netlify/config`, but patching third-party packages for a local-development-only condition adds a maintenance tax on every future netlify-cli bump, for a problem CI and production never hit. That approach was rejected; this is the work-with-it alternative.

## What

The tracing suite detects a worktree checkout (`.git` is a file) and skips explicitly with a comment explaining why, instead of failing noisily. CI and any standard clone keep full coverage — including the deploy-contract test from #250.

## Verification

- Standard checkout: both tests run and pass (Node 24), lint/format clean.
- Fresh throwaway worktree at this commit: both tests skip.