### PR TITLE
Fixed Vitest discovering tests from nested worktrees

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -2,6 +2,10 @@ import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
     test: {
+        include: [
+            'packages/*/test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}',
+            'test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}'
+        ],
         coverage: {
             provider: 'custom',
             customProviderModule: './test/coverage-provider.mjs',


### PR DESCRIPTION
## Summary

- restrict root Vitest discovery to repository-owned package and root test directories
- prevent ignored local worktrees from contributing stale tests and dependency failures

## Testing

- `nvm use 24 && pnpm test`
- `nvm use 24 && pnpm test:coverage`
- `git diff --check`