### PR TITLE
Fix Netlify acceptance test timeouts

### DIFF
--- a/packages/algolia-netlify/package.json
+++ b/packages/algolia-netlify/package.json
@@ -30,15 +30,15 @@
   },
   "scripts": {
     "dev": "pnpm --dir ../.. exec netlify dev --filter @tryghost/algolia-netlify",
-    "prebuild": "pnpm --filter @tryghost/algolia-html-extractor build && pnpm --filter @tryghost/algolia-fragmenter build",
-    "pretest": "pnpm --filter @tryghost/algolia-html-extractor build && pnpm --filter @tryghost/algolia-fragmenter build",
+    "prebuild": "pnpm --filter @tryghost/algolia-fragmenter build",
+    "pretest": "pnpm --filter @tryghost/algolia-fragmenter build",
     "test": "NODE_ENV=testing vitest run --root .",
     "typecheck": "tsc --project tsconfig.functions.json && tsc --project tsconfig.test.json",
     "lint": "oxlint --quiet . && oxfmt --check .",
     "posttest": "pnpm typecheck && pnpm lint",
     "build": "NODE_ENV=production pnpm --dir ../.. exec netlify build --offline --filter @tryghost/algolia-netlify",
     "build:package": "node scripts/build-package.mjs && tsc --project tsconfig.package.json && node scripts/clean-package.mjs",
-    "prepack": "pnpm --filter @tryghost/algolia-html-extractor build && pnpm --filter @tryghost/algolia-fragmenter build && pnpm build:package"
+    "prepack": "pnpm --filter @tryghost/algolia-fragmenter build && pnpm build:package"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

- route Netlify lifecycle hooks through the fragmenter build
- rely on the fragmenter prebuild to build the extractor exactly once
- preserve the existing 30-second acceptance budgets and fresh dependency output

## Verification

- exact Netlify acceptance pair: 3 tests passed in 9.7 seconds
- three concurrent acceptance-pair runs: all passed in about 13.3 seconds each
- focused Netlify package: 47 tests, typecheck, lint, and formatting passed
- full repository: 277 tests, typecheck, lint, and formatting passed
- standards and spec re-review: no findings

Ref #220